### PR TITLE
Fix: fix linker errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,8 +71,7 @@ function compile_native() {
     export AR=ar
     compile_objs
     echo "linking..."
-    $AR -rcs out/libmocha.a out/*.o
-    $CC -Iinclude -Lout -lmocha tests/mo_shell.c -o out/mo_shell
+    $CC -Iinclude -Lout -lm tests/mo_shell.c out/*.o -o out/mo_shell
     echo "mocha shell compiled!"
 }
 


### PR DESCRIPTION
When I tried to build mocha1995 on my system, I've got these errors:
```console
mrunix@fedora:~/mocha1995$ compile_native
compiling OBJS...
linking...
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o: in function `main':
mo_shell.c:(.text+0x4c): undefined reference to `MOCHA_NewContext'
/usr/bin/ld: mo_shell.c:(.text+0x90): undefined reference to `MOCHA_NewObject'
/usr/bin/ld: mo_shell.c:(.text+0xb8): undefined reference to `MOCHA_HoldObject'
/usr/bin/ld: mo_shell.c:(.text+0xc5): undefined reference to `MOCHA_SetGlobalObject'
/usr/bin/ld: mo_shell.c:(.text+0xd8): undefined reference to `MOCHA_SetErrorReporter'
/usr/bin/ld: mo_shell.c:(.text+0xef): undefined reference to `MOCHA_DefineFunctions'
/usr/bin/ld: mo_shell.c:(.text+0x139): undefined reference to `MOCHA_DefineNewObject'
/usr/bin/ld: mo_shell.c:(.text+0x1a0): undefined reference to `MOCHA_DropObject'
/usr/bin/ld: mo_shell.c:(.text+0x1a9): undefined reference to `MOCHA_DestroyContext'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o: in function `Process':
mo_shell.c:(.text+0x3ea): undefined reference to `mocha_NewFileTokenStream'
/usr/bin/ld: mo_shell.c:(.text+0x403): undefined reference to `mocha_NewBufferTokenStream'
/usr/bin/ld: mo_shell.c:(.text+0x481): undefined reference to `mocha_InitCodeGenerator'
/usr/bin/ld: mo_shell.c:(.text+0x568): undefined reference to `mocha_Parse'
/usr/bin/ld: mo_shell.c:(.text+0x5d1): undefined reference to `mocha_InitAtomMap'
/usr/bin/ld: mo_shell.c:(.text+0x5ea): undefined reference to `mocha_FinishTakingSourceNotes'
/usr/bin/ld: mo_shell.c:(.text+0x611): undefined reference to `MOCHA_ExecuteScript'
/usr/bin/ld: mo_shell.c:(.text+0x66e): undefined reference to `MOCHA_DatumToString'
/usr/bin/ld: mo_shell.c:(.text+0x6a3): undefined reference to `mocha_DropAtom'
/usr/bin/ld: mo_shell.c:(.text+0x6b3): undefined reference to `mocha_DropRef'
/usr/bin/ld: mo_shell.c:(.text+0x6cd): undefined reference to `mocha_FreeAtomMap'
/usr/bin/ld: mo_shell.c:(.text+0x6db): undefined reference to `mocha_CloseTokenStream'
/usr/bin/ld: mo_shell.c:(.text+0x6e8): undefined reference to `PR_FreeArenaPool'
/usr/bin/ld: mo_shell.c:(.text+0x6f5): undefined reference to `PR_FreeArenaPool'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o: in function `Load':
mo_shell.c:(.text+0x771): undefined reference to `MOCHA_DatumToString'
/usr/bin/ld: mo_shell.c:(.text+0x7ae): undefined reference to `MOCHA_CompileFile'
/usr/bin/ld: mo_shell.c:(.text+0x7bf): undefined reference to `mocha_DropAtom'
/usr/bin/ld: mo_shell.c:(.text+0x851): undefined reference to `MOCHA_ExecuteScript'
/usr/bin/ld: mo_shell.c:(.text+0x867): undefined reference to `mocha_DropRef'
/usr/bin/ld: mo_shell.c:(.text+0x874): undefined reference to `MOCHA_DestroyScript'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o: in function `Print':
mo_shell.c:(.text+0x905): undefined reference to `MOCHA_DatumToString'
/usr/bin/ld: mo_shell.c:(.text+0x95e): undefined reference to `mocha_DropAtom'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o: in function `Help':
mo_shell.c:(.text+0xa63): undefined reference to `mocha_HoldAtom'
/usr/bin/ld: mo_shell.c:(.text+0xaa2): undefined reference to `mocha_HoldAtom'
/usr/bin/ld: mo_shell.c:(.text+0xb63): undefined reference to `mocha_DropAtom'
/usr/bin/ld: mo_shell.c:(.text+0xba1): undefined reference to `MOCHA_DatumToString'
/usr/bin/ld: mo_shell.c:(.text+0xbe4): undefined reference to `mocha_DropAtom'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x8): undefined reference to `MOCHA_PropertyStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x10): undefined reference to `MOCHA_PropertyStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x18): undefined reference to `MOCHA_ListPropStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x20): undefined reference to `MOCHA_ResolveStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x28): undefined reference to `MOCHA_ConvertStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x30): undefined reference to `MOCHA_FinalizeStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0xe8): undefined reference to `MOCHA_PropertyStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0xf0): undefined reference to `MOCHA_PropertyStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0xf8): undefined reference to `MOCHA_ListPropStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x100): undefined reference to `MOCHA_ResolveStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x108): undefined reference to `MOCHA_ConvertStub'
/usr/bin/ld: /tmp/mo_shell-7e3fb6.o:(.data+0x110): undefined reference to `MOCHA_FinalizeStub'
```
This PR fixes it