### PR TITLE
feat: modern web playground with interactive engine debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 .DS_Store
 .vscode
 out
+
+# Web playground
+web/node_modules
+web/dist
+web/.vite
+web/*.tsbuildinfo
+web/**/*.tsbuildinfo
+
+# Built engine artifacts (regenerate with build_wasm.sh)
+web/public/engine/mocha.mjs
+web/public/engine/mocha.wasm

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ Besides native binary, the ported Mocha engine can also be compiled to WASM and 
 * [WASM Version](https://mocha1995.js.org)
 * [JavaScript Version](https://mocha1995.js.org#js)
 
+## Modern Playground & Engine Debugger
+A modern web playground lives in [`web/`](./web) — a Vite + React + TypeScript + Tailwind app that runs the engine (compiled to WebAssembly) and **visualizes how it works**: the scanner's token stream, the compiled bytecode, and an interactive step-debugger over the real execution trace (value stack, call stack and per-instruction state), plus charts for the compiler pipeline, execution timeline and opcode profile.
+
+```sh
+# Build the engine to WASM (needs Emscripten on PATH, e.g. `source emsdk_env.sh`)
+$ bash build_wasm.sh
+
+# Run the playground
+$ cd web && npm install && npm run dev
+```
+
+The instrumentation that powers this is intentionally minimal: a single `mocha_TraceHook` call added to the interpreter loop (`src/mocha.c`) plus a self-contained embedder, `src/mo_web.c`, that emits the engine's internals as JSON. See [`web/README.md`](./web/README.md) for details.
+
 ## Build
 For WASM and JS build, please make sure [Emscripten](https://emscripten.org/docs/getting_started/downloads.html) is installed and activated (`emcc` command is available):
 

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Build the Mocha 1995 engine to a WebAssembly ES module for the playground.
+#
+# Requires Emscripten (`emcc` on PATH).  If you used emsdk, run:
+#     source /path/to/emsdk/emsdk_env.sh
+#
+# Output: web/public/engine/mocha.mjs + mocha.wasm
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+OUT="$ROOT/out/wasm"
+DEST="$ROOT/web/public/engine"
+
+ENGINE_SRCS=(
+  mo_array mo_atom mo_bcode mo_bool mo_cntxt mo_date mo_emit mo_fun
+  mo_math mo_num mo_obj mo_parse mo_scan mo_scope mo_str mocha mochaapi
+  mochalib prmjtime prtime prarena prhash prprf prdtoa log2 longlong
+)
+
+if ! command -v emcc >/dev/null 2>&1; then
+  echo "error: emcc not found. Install Emscripten and 'source emsdk_env.sh'." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT" "$DEST"
+
+echo "compiling engine objects..."
+for f in "${ENGINE_SRCS[@]}"; do
+  emcc -w -O2 -I"$ROOT/include" -c "$ROOT/src/$f.c" -o "$OUT/$f.o"
+done
+
+echo "linking mocha.mjs..."
+emcc -O2 -I"$ROOT/include" "$ROOT/src/mo_web.c" "$OUT"/*.o \
+  -s MODULARIZE=1 \
+  -s EXPORT_ES6=1 \
+  -s ENVIRONMENT=web,node \
+  -s ALLOW_MEMORY_GROWTH=1 \
+  -s INITIAL_MEMORY=33554432 \
+  -s "EXPORTED_FUNCTIONS=['_mocha_run_json','_free','_malloc']" \
+  -s "EXPORTED_RUNTIME_METHODS=['ccall','cwrap','UTF8ToString','stringToUTF8','lengthBytesUTF8']" \
+  -o "$OUT/mocha.mjs"
+
+cp "$OUT/mocha.mjs" "$OUT/mocha.wasm" "$DEST/"
+echo "done -> $DEST/mocha.mjs (+ mocha.wasm)"

--- a/include/mo_introspect.h
+++ b/include/mo_introspect.h
@@ -1,0 +1,31 @@
+/*
+** Mocha introspection hook.
+**
+** A minimal, always-compiled instrumentation point for the bytecode
+** interpreter, used by the web playground to capture a structured
+** execution trace.  When `mocha_TraceHook` is non-null, the interpreter
+** calls it once per bytecode instruction, just before the instruction is
+** dispatched.  This lets an embedder snapshot the program counter, the
+** value stack and the active call frame without patching the interpreter
+** beyond a single call.
+*/
+#ifndef mo_introspect_h___
+#define mo_introspect_h___
+
+#include "mo_pubtd.h"
+#include "mocha.h"
+
+typedef void (*MochaTraceHook)(MochaContext *mc, MochaScript *script,
+                               MochaCode *pc, struct MochaStack *sp);
+
+extern MochaTraceHook mocha_TraceHook;
+
+/*
+** Compile and run `source`, returning a freshly malloc'd JSON string that
+** describes the token stream, the disassembled bytecode of every executed
+** script, a per-instruction execution trace and the program output.
+** The caller owns the returned string and must free() it.
+*/
+extern char *mocha_run_json(const char *source);
+
+#endif /* mo_introspect_h___ */

--- a/src/mo_web.c
+++ b/src/mo_web.c
@@ -1,0 +1,738 @@
+/*
+** Mocha web embedder + introspection.
+**
+** Self-contained Emscripten entry point for the modern playground.  It
+** compiles a source string with the original 1995 engine and emits a
+** single JSON document describing:
+**
+**   - tokens   : the scanner's token stream (type, text, line, column)
+**   - scripts  : disassembled bytecode for every executed script/function
+**   - trace    : a per-instruction execution trace (pc, value stack, frame)
+**   - output   : everything written by print()
+**   - error    : the first compile/runtime error, if any
+**   - result   : the value of the final top-level expression
+**
+** Nothing here is gated behind -DDEBUG; the engine stays a black box apart
+** from the single mocha_TraceHook call wired into the interpreter loop.
+*/
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "prlog.h"
+#include "mo_atom.h"
+#include "mo_bcode.h"
+#include "mo_cntxt.h"
+#include "mo_emit.h"
+#include "mo_parse.h"
+#include "mo_scan.h"
+#include "mo_scope.h"
+#include "mocha.h"
+#include "mochaapi.h"
+#include "mochalib.h"
+#include "mo_introspect.h"
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#define EXPORT EMSCRIPTEN_KEEPALIVE
+#else
+#define EXPORT
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Growable string buffer                                              */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    char   *p;
+    size_t  len;
+    size_t  cap;
+    int     oom;
+} StrBuf;
+
+static void
+sb_reset(StrBuf *b)
+{
+    if (b->p) free(b->p);
+    b->p = 0;
+    b->len = 0;
+    b->cap = 0;
+    b->oom = 0;
+}
+
+static void
+sb_need(StrBuf *b, size_t extra)
+{
+    size_t nc;
+    char *np;
+
+    if (b->oom)
+        return;
+    if (b->len + extra + 1 <= b->cap)
+        return;
+    nc = b->cap ? b->cap : 256;
+    while (nc < b->len + extra + 1)
+        nc *= 2;
+    np = realloc(b->p, nc);
+    if (!np) {
+        b->oom = 1;
+        return;
+    }
+    b->p = np;
+    b->cap = nc;
+}
+
+static void
+sb_putc(StrBuf *b, char c)
+{
+    sb_need(b, 1);
+    if (b->oom)
+        return;
+    b->p[b->len++] = c;
+    b->p[b->len] = 0;
+}
+
+static void
+sb_puts(StrBuf *b, const char *s)
+{
+    size_t n;
+
+    if (!s)
+        return;
+    n = strlen(s);
+    sb_need(b, n);
+    if (b->oom)
+        return;
+    memcpy(b->p + b->len, s, n);
+    b->len += n;
+    b->p[b->len] = 0;
+}
+
+static void
+sb_putf(StrBuf *b, const char *fmt, ...)
+{
+    char tmp[128];
+    va_list ap;
+    int n;
+
+    va_start(ap, fmt);
+    n = vsnprintf(tmp, sizeof tmp, fmt, ap);
+    va_end(ap);
+    if (n < 0)
+        return;
+    if ((size_t)n < sizeof tmp) {
+        sb_puts(b, tmp);
+        return;
+    }
+    sb_need(b, (size_t)n);
+    if (b->oom)
+        return;
+    va_start(ap, fmt);
+    vsnprintf(b->p + b->len, (size_t)n + 1, fmt, ap);
+    va_end(ap);
+    b->len += (size_t)n;
+}
+
+/* Append `s` as a JSON string literal, with escaping. */
+static void
+sb_jstr(StrBuf *b, const char *s)
+{
+    unsigned char c;
+
+    sb_putc(b, '"');
+    if (s) {
+        for (; (c = (unsigned char)*s) != 0; s++) {
+            switch (c) {
+              case '"':  sb_puts(b, "\\\""); break;
+              case '\\': sb_puts(b, "\\\\"); break;
+              case '\n': sb_puts(b, "\\n");  break;
+              case '\r': sb_puts(b, "\\r");  break;
+              case '\t': sb_puts(b, "\\t");  break;
+              default:
+                if (c < 0x20)
+                    sb_putf(b, "\\u%04x", c);
+                else
+                    sb_putc(b, (char)c);
+            }
+        }
+    }
+    sb_putc(b, '"');
+}
+
+/* ------------------------------------------------------------------ */
+/* Static lookup tables                                               */
+/* ------------------------------------------------------------------ */
+
+static const char *token_names[] = {
+    "EOF", "EOL", "SEMI", "LB", "RB", "LC", "RC", "LP", "RP", "COMMA",
+    "ASSIGN", "HOOK", "COLON", "OR", "AND", "BITOR", "BITXOR", "BITAND",
+    "EQOP", "RELOP", "SHOP", "PLUS", "MINUS", "MULOP", "UNARYOP", "INCOP",
+    "DOT", "NAME", "NUMBER", "STRING", "PRIMARY", "FUNCTION", "IF", "ELSE",
+    "SWITCH", "CASE", "DEFAULT", "WHILE", "DO", "FOR", "BREAK", "CONTINUE",
+    "IN", "VAR", "WITH", "RETURN", "NEW", "RESERVED"
+};
+
+/* Representative lexeme for fixed-shape tokens (NAME/NUMBER/STRING are
+   captured from source instead). */
+static const char *token_lexemes[] = {
+    "", "", ";", "[", "]", "{", "}", "(", ")", ",",
+    "=", "?", ":", "||", "&&", "|", "^", "&",
+    "==", "<", "<<", "+", "-", "*", "!", "++",
+    ".", "", "", "", "", "function", "if", "else",
+    "switch", "case", "default", "while", "do", "for", "break", "continue",
+    "in", "var", "with", "return", "new", "reserved"
+};
+
+static const char *
+datum_type_name(uint8 tag)
+{
+    switch (tag) {
+      case MOCHA_UNDEF:    return "undefined";
+      case MOCHA_INTERNAL: return "internal";
+      case MOCHA_ATOM:     return "atom";
+      case MOCHA_SYMBOL:   return "symbol";
+      case MOCHA_FUNCTION: return "function";
+      case MOCHA_OBJECT:   return "object";
+      case MOCHA_NUMBER:   return "number";
+      case MOCHA_BOOLEAN:  return "boolean";
+      case MOCHA_STRING:   return "string";
+      default:             return "unknown";
+    }
+}
+
+static const char *
+op_format_name(MochaOpFormat f)
+{
+    switch (f) {
+      case MOF_BYTE:  return "byte";
+      case MOF_JUMP:  return "jump";
+      case MOF_INCOP: return "incop";
+      case MOF_ARGC:  return "argc";
+      case MOF_CONST: return "const";
+      default:        return "byte";
+    }
+}
+
+/*
+** Serialize a datum without invoking any user code (no toString / valueOf),
+** so it is safe to call from the per-instruction trace hook.
+*/
+static void
+emit_datum(StrBuf *b, MochaDatum d)
+{
+    char num[40];
+
+    sb_puts(b, "{\"type\":");
+    sb_jstr(b, datum_type_name(d.tag));
+    sb_puts(b, ",\"value\":");
+    switch (d.tag) {
+      case MOCHA_NUMBER:
+        if (d.u.fval != d.u.fval) {
+            sb_jstr(b, "NaN");
+        } else {
+            snprintf(num, sizeof num, "%.15g", (double)d.u.fval);
+            sb_jstr(b, num);
+        }
+        break;
+      case MOCHA_BOOLEAN:
+        sb_jstr(b, d.u.bval ? "true" : "false");
+        break;
+      case MOCHA_STRING:
+      case MOCHA_ATOM:
+        sb_jstr(b, d.u.atom ? atom_name(d.u.atom) : "");
+        break;
+      case MOCHA_UNDEF:
+        sb_jstr(b, "undefined");
+        break;
+      case MOCHA_FUNCTION:
+        sb_jstr(b, (d.u.fun && d.u.fun->atom) ? atom_name(d.u.fun->atom)
+                                              : "function");
+        break;
+      case MOCHA_OBJECT:
+        sb_jstr(b, (d.u.obj && d.u.obj->clazz) ? d.u.obj->clazz->name
+                                               : "object");
+        break;
+      case MOCHA_SYMBOL:
+        sb_jstr(b, d.u.pair.sym ? atom_name(sym_atom(d.u.pair.sym)) : "symbol");
+        break;
+      default:
+        sb_jstr(b, "?");
+    }
+    sb_putc(b, '}');
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-run global state                                               */
+/* ------------------------------------------------------------------ */
+
+#define MAX_SCRIPTS  256
+#define MAX_STEPS    300000
+#define MAX_TRACE_BYTES (24 * 1024 * 1024)
+#define STACK_WINDOW 32
+
+static MochaScript *g_scripts[MAX_SCRIPTS];
+static const char  *g_script_names[MAX_SCRIPTS];
+static int          g_nscripts;
+
+static StrBuf g_trace;
+static StrBuf g_output;
+static StrBuf g_error;
+static int    g_haserror;
+static int    g_step;
+static int    g_truncated;
+static int    g_in_hook;
+
+static int
+script_id(MochaScript *s, const char *name)
+{
+    int i;
+
+    for (i = 0; i < g_nscripts; i++)
+        if (g_scripts[i] == s)
+            return i;
+    if (g_nscripts < MAX_SCRIPTS) {
+        g_scripts[g_nscripts] = s;
+        g_script_names[g_nscripts] = name;
+        return g_nscripts++;
+    }
+    return g_nscripts - 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* The trace hook                                                     */
+/* ------------------------------------------------------------------ */
+
+static void
+trace_hook(MochaContext *mc, MochaScript *script, MochaCode *pc,
+           struct MochaStack *sp)
+{
+    MochaOp op;
+    MochaCodeSpec *cs;
+    MochaStackFrame *fr;
+    MochaDatum *base, *top;
+    const char *nm;
+    long count, start, i;
+    int sid, depth;
+    unsigned argi;
+
+    if (g_in_hook)
+        return;
+    if (g_step >= MAX_STEPS || g_trace.len >= MAX_TRACE_BYTES) {
+        g_truncated = 1;
+        return;
+    }
+    g_in_hook = 1;
+
+    fr = sp->frame;
+    nm = (fr && fr->fun && fr->fun->atom && fr->fun->script == script)
+         ? atom_name(fr->fun->atom) : 0;
+    sid = script_id(script, nm);
+
+    op = *pc;
+    cs = &mocha_CodeSpec[op];
+
+    depth = 0;
+    {
+        MochaStackFrame *f;
+        for (f = sp->frame; f; f = f->down)
+            depth++;
+    }
+
+    if (g_step)
+        sb_putc(&g_trace, ',');
+    sb_putf(&g_trace, "{\"step\":%d,\"script\":%d,\"pc\":%u,\"line\":%u,\"op\":",
+            g_step, sid, (unsigned)(pc - script->code),
+            mocha_PCtoLineNumber(script, pc));
+    sb_jstr(&g_trace, cs->name);
+    sb_putf(&g_trace, ",\"depth\":%d,\"stack\":[", depth);
+
+    base = sp->base;
+    top = sp->ptr;
+    count = (long)(top - base);
+    start = (count > STACK_WINDOW) ? count - STACK_WINDOW : 0;
+    for (i = start; i < count; i++) {
+        if (i > start)
+            sb_putc(&g_trace, ',');
+        emit_datum(&g_trace, base[i]);
+    }
+    sb_puts(&g_trace, "]");
+
+    if (fr) {
+        sb_puts(&g_trace, ",\"frame\":{\"fn\":");
+        sb_jstr(&g_trace, (fr->fun && fr->fun->atom)
+                          ? atom_name(fr->fun->atom) : "anonymous");
+        sb_puts(&g_trace, ",\"args\":[");
+        for (argi = 0; argi < fr->argc; argi++) {
+            if (argi)
+                sb_putc(&g_trace, ',');
+            emit_datum(&g_trace, fr->argv[argi]);
+        }
+        sb_puts(&g_trace, "],\"vars\":[");
+        for (argi = 0; argi < fr->nvars; argi++) {
+            if (argi)
+                sb_putc(&g_trace, ',');
+            emit_datum(&g_trace, fr->vars[argi]);
+        }
+        sb_puts(&g_trace, "]}");
+    } else {
+        sb_puts(&g_trace, ",\"frame\":null");
+    }
+
+    sb_putc(&g_trace, '}');
+    g_step++;
+    g_in_hook = 0;
+}
+
+static MochaBoolean
+branch_cb(MochaContext *mc, MochaScript *script)
+{
+    if (g_step >= MAX_STEPS) {
+        g_truncated = 1;
+        return MOCHA_FALSE;     /* abort runaway loops cleanly */
+    }
+    return MOCHA_TRUE;
+}
+
+/* ------------------------------------------------------------------ */
+/* Bytecode disassembly (one executed script)                        */
+/* ------------------------------------------------------------------ */
+
+static void
+emit_script_bytecode(StrBuf *b, MochaContext *mc, MochaScript *script)
+{
+    MochaCode *pc, *end;
+    MochaOp op;
+    MochaCodeSpec *cs;
+    MochaAtom *atom;
+    unsigned off, len;
+    int first = 1;
+    char num[40];
+
+    pc = script->code;
+    end = pc + script->length;
+    sb_putc(b, '[');
+    while (pc < end) {
+        op = *pc;
+        if (op >= MOP_MAX)
+            break;
+        cs = &mocha_CodeSpec[op];
+        if (!first)
+            sb_putc(b, ',');
+        first = 0;
+        off = (unsigned)(pc - script->code);
+        sb_putf(b, "{\"offset\":%u,\"op\":", off);
+        sb_jstr(b, cs->name);
+        sb_putf(b, ",\"length\":%u,\"nuses\":%d,\"ndefs\":%d,\"line\":%u,"
+                   "\"format\":",
+                cs->length, cs->nuses, cs->ndefs,
+                mocha_PCtoLineNumber(script, pc));
+        sb_jstr(b, op_format_name(cs->format));
+        sb_puts(b, ",\"operand\":");
+        switch (cs->format) {
+          case MOF_JUMP: {
+            int delta = GET_JUMP_OFFSET(pc);
+            sb_putf(b, "{\"target\":%u,\"delta\":%d}",
+                    (unsigned)(off + delta), delta);
+            break;
+          }
+          case MOF_INCOP:
+            sb_jstr(b, pc[1] ? "post" : "pre");
+            break;
+          case MOF_ARGC:
+            sb_putf(b, "%u", pc[1]);
+            break;
+          case MOF_CONST:
+            atom = GET_CONST_ATOM(mc, script, pc);
+            if (op == MOP_NUMBER && atom) {
+                snprintf(num, sizeof num, "%.15g", (double)atom->fval);
+                sb_jstr(b, num);
+            } else {
+                sb_jstr(b, atom ? atom_name(atom) : "");
+            }
+            break;
+          default:
+            sb_puts(b, "null");
+        }
+        sb_putc(b, '}');
+        len = cs->length ? cs->length : 1;
+        pc += len;
+    }
+    sb_putc(b, ']');
+}
+
+/* ------------------------------------------------------------------ */
+/* Token stream                                                       */
+/* ------------------------------------------------------------------ */
+
+static void
+emit_tokens(StrBuf *b, MochaContext *mc, const char *src)
+{
+    MochaTokenStream *ts;
+    CodeGenerator cg;
+    MochaTokenType tt;
+    int first = 1, idx = 0;
+
+    sb_putc(b, '[');
+    ts = mocha_NewBufferTokenStream(mc, src, strlen(src));
+    if (!ts) {
+        sb_putc(b, ']');
+        return;
+    }
+    mocha_InitCodeGenerator(mc, &cg, &mc->tempPool);
+    CG_RESET(&cg);
+
+    for (;;) {
+        unsigned line;
+        int col;
+
+        tt = mocha_GetToken(mc, ts, &cg);
+        if (tt == TOK_EOF || (int)tt < 0 || tt >= TOK_MAX)
+            break;
+        if (tt == TOK_EOL)
+            continue;
+        if (ts->flags & TSF_EOF)
+            ;   /* still record this final token */
+
+        line = ts->lineno;
+        col = (ts->token.ptr && ts->linebuf.base)
+              ? (int)(ts->token.ptr - ts->linebuf.base) : 0;
+
+        if (!first)
+            sb_putc(b, ',');
+        first = 0;
+        sb_putf(b, "{\"index\":%d,\"type\":", idx++);
+        sb_jstr(b, token_names[tt]);
+        sb_putf(b, ",\"line\":%u,\"col\":%d,\"text\":", line, col);
+        if (tt == TOK_NAME || tt == TOK_STRING) {
+            sb_jstr(b, ts->token.u.atom ? atom_name(ts->token.u.atom)
+                       : (ts->tokenbuf.base ? ts->tokenbuf.base : ""));
+        } else if (tt == TOK_NUMBER) {
+            char num[40];
+            snprintf(num, sizeof num, "%.15g",
+                     ts->token.u.atom ? (double)ts->token.u.atom->fval : 0.0);
+            sb_jstr(b, num);
+        } else {
+            sb_jstr(b, token_lexemes[tt]);
+        }
+        sb_putc(b, '}');
+
+        if (b->oom || idx > 200000 || (ts->flags & TSF_EOF))
+            break;
+    }
+    sb_putc(b, ']');
+    mocha_CloseTokenStream(ts);
+}
+
+/* ------------------------------------------------------------------ */
+/* Native print + error reporter (capture, no stdout)                */
+/* ------------------------------------------------------------------ */
+
+static MochaBoolean
+js_print(MochaContext *mc, MochaObject *obj,
+         unsigned argc, MochaDatum *argv, MochaDatum *rval)
+{
+    unsigned i;
+    MochaAtom *atom;
+
+    for (i = 0; i < argc; i++) {
+        if (!MOCHA_DatumToString(mc, argv[i], &atom))
+            return MOCHA_FALSE;
+        if (i)
+            sb_putc(&g_output, ' ');
+        sb_puts(&g_output, atom_name(atom));
+        mocha_DropAtom(mc, atom);
+    }
+    sb_putc(&g_output, '\n');
+    return MOCHA_TRUE;
+}
+
+static void
+js_error_reporter(MochaContext *mc, const char *message,
+                  MochaErrorReport *report)
+{
+    g_haserror = 1;
+    if (g_error.len)
+        return;     /* keep the first error */
+    sb_puts(&g_error, "{\"message\":");
+    sb_jstr(&g_error, message ? message : "error");
+    if (report) {
+        int col = (report->linebuf && report->tokenptr)
+                  ? (int)(report->tokenptr - report->linebuf) : -1;
+        sb_putf(&g_error, ",\"line\":%u,\"col\":%d,\"linebuf\":",
+                report->lineno, col);
+        sb_jstr(&g_error, report->linebuf ? report->linebuf : "");
+    } else {
+        sb_puts(&g_error, ",\"line\":0,\"col\":-1,\"linebuf\":\"\"");
+    }
+    sb_putc(&g_error, '}');
+}
+
+static MochaClass global_class = {
+    "global",
+    MOCHA_PropertyStub, MOCHA_PropertyStub, MOCHA_ListPropStub,
+    MOCHA_ResolveStub,  MOCHA_ConvertStub,  MOCHA_FinalizeStub
+};
+
+static MochaFunctionSpec web_functions[] = {
+    {"print", js_print, 0},
+    {0}
+};
+
+/* Stubs so we need not link the Java glue (mirrors mo_shell.c). */
+MochaBoolean
+mocha_InitJava(MochaContext *mc, MochaObject *obj)
+{
+    return MOCHA_TRUE;
+}
+
+void
+mocha_DestroyJavaContext(MochaContext *mc)
+{
+}
+
+/* The trace-hook global the interpreter calls (default: disabled). */
+MochaTraceHook mocha_TraceHook = 0;
+
+/* ------------------------------------------------------------------ */
+/* Entry point                                                        */
+/* ------------------------------------------------------------------ */
+
+EXPORT char *
+mocha_run_json(const char *source)
+{
+    MochaContext *mc;
+    MochaObject *glob;
+    MochaScript *script;
+    MochaDatum result;
+    StrBuf tokens = {0};
+    StrBuf out = {0};
+    MochaBoolean ok = MOCHA_FALSE;
+    int i;
+
+    /* Reset per-run state. */
+    sb_reset(&g_trace);
+    sb_reset(&g_output);
+    sb_reset(&g_error);
+    g_haserror = 0;
+    g_step = 0;
+    g_truncated = 0;
+    g_in_hook = 0;
+    g_nscripts = 0;
+
+    if (!source)
+        source = "";
+
+    mc = MOCHA_NewContext(8192);
+    if (!mc) {
+        char *e = malloc(64);
+        if (e) strcpy(e, "{\"ok\":false,\"error\":{\"message\":\"no context\"}}");
+        return e;
+    }
+
+    glob = MOCHA_NewObject(mc, &global_class, 0, 0, 0, 0, 0);
+    if (!glob) {
+        MOCHA_DestroyContext(mc);
+        return strdup("{\"ok\":false,\"error\":{\"message\":\"no global\"}}");
+    }
+    MOCHA_HoldObject(mc, glob);
+    MOCHA_SetGlobalObject(mc, glob);
+    MOCHA_SetErrorReporter(mc, js_error_reporter);
+    MOCHA_DefineFunctions(mc, glob, web_functions);
+
+    /* Phase 1: token stream (independent scan). */
+    emit_tokens(&tokens, mc, source);
+
+    /* Phase 2: compile. */
+    result = MOCHA_void;
+    script = MOCHA_CompileBuffer(mc, glob, source, strlen(source),
+                                 "<playground>", 1);
+    if (script) {
+        script_id(script, "<main>");
+        mocha_TraceHook = trace_hook;
+        MOCHA_SetBranchCallback(mc, branch_cb);
+        ok = MOCHA_ExecuteScript(mc, glob, script, &result);
+        mocha_TraceHook = 0;
+        MOCHA_SetBranchCallback(mc, 0);
+    }
+
+    /* Phase 3: assemble JSON. */
+    sb_putc(&out, '{');
+    sb_puts(&out, "\"ok\":");
+    sb_puts(&out, (ok && !g_haserror) ? "true" : "false");
+
+    sb_puts(&out, ",\"output\":");
+    sb_jstr(&out, g_output.p ? g_output.p : "");
+
+    sb_puts(&out, ",\"error\":");
+    if (g_haserror && g_error.p)
+        sb_puts(&out, g_error.p);
+    else
+        sb_puts(&out, "null");
+
+    sb_puts(&out, ",\"result\":");
+    if (ok)
+        emit_datum(&out, result);
+    else
+        sb_puts(&out, "null");
+
+    sb_puts(&out, ",\"tokens\":");
+    sb_puts(&out, tokens.p ? tokens.p : "[]");
+
+    sb_puts(&out, ",\"scripts\":[");
+    for (i = 0; i < g_nscripts; i++) {
+        if (i)
+            sb_putc(&out, ',');
+        sb_putf(&out, "{\"id\":%d,\"name\":", i);
+        sb_jstr(&out, g_script_names[i] ? g_script_names[i] : "fn");
+        sb_puts(&out, ",\"bytecode\":");
+        emit_script_bytecode(&out, mc, g_scripts[i]);
+        sb_putc(&out, '}');
+    }
+    sb_puts(&out, "]");
+
+    sb_puts(&out, ",\"trace\":[");
+    if (g_trace.p)
+        sb_puts(&out, g_trace.p);
+    sb_puts(&out, "]");
+
+    sb_puts(&out, ",\"truncated\":");
+    sb_puts(&out, g_truncated ? "true" : "false");
+    sb_putf(&out, ",\"stats\":{\"steps\":%d,\"scripts\":%d}", g_step, g_nscripts);
+    sb_putc(&out, '}');
+
+    if (script)
+        MOCHA_DestroyScript(mc, script);
+    if (ok)
+        mocha_DropRef(mc, &result);
+    MOCHA_DropObject(mc, glob);
+    MOCHA_DestroyContext(mc);
+
+    sb_reset(&tokens);
+    sb_reset(&g_trace);
+    sb_reset(&g_output);
+    sb_reset(&g_error);
+
+    if (out.oom) {
+        sb_reset(&out);
+        return strdup("{\"ok\":false,\"error\":{\"message\":\"out of memory\"}}");
+    }
+    return out.p;   /* caller frees */
+}
+
+/* Allow standalone native testing: ./mo_web 'print(1+2)' */
+#ifndef __EMSCRIPTEN__
+int
+main(int argc, char **argv)
+{
+    char *json;
+    const char *src = (argc > 1) ? argv[1] : "print('hello mocha')";
+    json = mocha_run_json(src);
+    if (json) {
+        fputs(json, stdout);
+        fputc('\n', stdout);
+        free(json);
+    }
+    return 0;
+}
+#endif

--- a/src/mocha.c
+++ b/src/mocha.c
@@ -17,6 +17,7 @@
 #include "mocha.h"
 #include "mochaapi.h"
 #include "mochalib.h"
+#include "mo_introspect.h"
 
 #ifdef DEBUG
 # include "mo_emit.h"	/* for mocha_PCtoLineNumber() */
@@ -844,6 +845,8 @@ mocha_Interpret(MochaContext *mc, MochaObject *slink, MochaScript *script,
 	op = *pc;
 	cs = &mocha_CodeSpec[op];
 	len = cs->length;
+	if (mocha_TraceHook)
+	    (*mocha_TraceHook)(mc, script, pc, sp);
 #ifdef DEBUG
 	if (mc->tracefp) {
 	    int nuses, n;

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,57 @@
+# Mocha 1995 — Playground & Engine Debugger
+
+A modern web playground for Brendan Eich's original 1995 JavaScript engine. It
+runs the **actual C engine** (compiled to WebAssembly) in your browser and
+visualizes its internals: the scanner's token stream, the compiled bytecode, and
+a full step-by-step execution trace.
+
+Stack: **Vite + React + TypeScript + Tailwind CSS v4**, with the engine exposed
+through a tiny instrumentation layer (`src/mo_web.c`, `src/mo_introspect.h`).
+
+## What you get
+
+- **Source editor** (CodeMirror) with the current debug line highlighted.
+- **Console** with `print()` output, the final value, and rich error reporting
+  (line, column, caret).
+- **Tokens** — the scanner output (`mo_scan.c`), colour-coded by class.
+- **Bytecode** — disassembled instructions per script/function (`mocha.def`),
+  with operands and jump targets; the active instruction is highlighted as you
+  step.
+- **Interactive debugger** — play / pause / step / step-over / scrub through
+  every interpreter instruction. The editor, bytecode, value stack, call stack
+  and charts all stay in sync with the current step.
+- **Value stack & call stack** — the real operand stack and call frames
+  (with argument values) at each step.
+- **Charts** — the engine pipeline (source → tokens → bytecode → interpreter),
+  an execution timeline (stack size & call depth over time), and an opcode
+  frequency profile.
+
+## How it works
+
+`src/mo_web.c` (in the repo root) embeds the engine and exposes a single
+exported function, `mocha_run_json(source)`, which compiles and runs a program
+and returns one JSON document describing the tokens, the disassembled bytecode of
+every executed script, a per-instruction execution trace (program counter, value
+stack, and call frame), the program output, and any error.
+
+The trace is captured through `mocha_TraceHook` — a one-line hook added to the
+interpreter loop in `src/mocha.c` that fires once per bytecode instruction. The
+engine is otherwise unmodified.
+
+## Develop
+
+```sh
+# 1. Build the engine to WebAssembly (requires Emscripten on PATH):
+#    source /path/to/emsdk/emsdk_env.sh
+npm run build:wasm        # -> public/engine/mocha.{mjs,wasm}
+
+# 2. Install deps and start the dev server:
+npm install
+npm run dev               # http://localhost:5173
+
+# Production build:
+npm run build && npm run preview
+```
+
+The `public/engine/*` artifacts are git-ignored; regenerate them with
+`build:wasm` (or `../build_wasm.sh`).

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <title>Mocha 1995 — Playground & Engine Debugger</title>
+    <meta name="description" content="Run, debug and visualize Brendan Eich's original 1995 JavaScript engine, compiled to WebAssembly." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,2807 @@
+{
+  "name": "mocha1995-playground",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mocha1995-playground",
+      "version": "1.0.0",
+      "dependencies": {
+        "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/state": "^6.4.1",
+        "@codemirror/view": "^6.34.1",
+        "@uiw/react-codemirror": "^4.23.6",
+        "clsx": "^2.1.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "zustand": "^5.0.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.6.3",
+        "vite": "^6.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
+      "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "tailwindcss": "4.3.1"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.10.tgz",
+      "integrity": "sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz",
+      "integrity": "sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.10",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "mocha1995-playground",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "build:wasm": "bash ../build_wasm.sh"
+  },
+  "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.2",
+    "@codemirror/state": "^6.4.1",
+    "@codemirror/view": "^6.34.1",
+    "@uiw/react-codemirror": "^4.23.6",
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.1"
+  }
+}

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#24160b"/>
+  <path d="M7 12h15v7a6 6 0 0 1-6 6h-3a6 6 0 0 1-6-6v-7z" fill="#e0954a"/>
+  <path d="M22 13h3a3 3 0 0 1 0 6h-3" fill="none" stroke="#e0954a" stroke-width="2"/>
+  <path d="M11 5c-1 1.5 0 2.5 0 4M16 5c-1 1.5 0 2.5 0 4" fill="none" stroke="#c9a47b" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,50 @@
+import { Toolbar } from './components/Toolbar'
+import { EditorPane } from './components/EditorPane'
+import { ConsolePanel } from './components/ConsolePanel'
+import { TokensPanel } from './components/TokensPanel'
+import { BytecodePanel } from './components/BytecodePanel'
+import { StackPanel } from './components/StackPanel'
+import { CallStackPanel } from './components/CallStackPanel'
+import { DebuggerControls } from './components/DebuggerControls'
+import { PipelinePanel } from './components/charts/PipelinePanel'
+import { StackDepthChart } from './components/charts/StackDepthChart'
+import { OpcodeChart } from './components/charts/OpcodeChart'
+import { usePlayLoop } from './hooks/usePlayLoop'
+
+export function App() {
+  usePlayLoop()
+
+  return (
+    <div className="flex h-screen flex-col bg-ink-900 text-ink-100">
+      <Toolbar />
+      <div className="border-b border-ink-600 bg-ink-800/60 px-2 py-2">
+        <DebuggerControls />
+      </div>
+
+      <main className="grid min-h-0 flex-1 grid-cols-1 gap-2 p-2 lg:grid-cols-12">
+        {/* Left: source + console */}
+        <div className="flex min-h-0 flex-col gap-2 lg:col-span-4">
+          <EditorPane />
+          <ConsolePanel />
+        </div>
+
+        {/* Middle: bytecode + runtime state */}
+        <div className="flex min-h-0 flex-col gap-2 lg:col-span-4">
+          <BytecodePanel />
+          <div className="grid min-h-0 flex-1 grid-cols-2 gap-2">
+            <StackPanel />
+            <CallStackPanel />
+          </div>
+        </div>
+
+        {/* Right: scanner + charts */}
+        <div className="flex min-h-0 flex-col gap-2 overflow-auto lg:col-span-4">
+          <PipelinePanel />
+          <TokensPanel />
+          <StackDepthChart />
+          <OpcodeChart />
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web/src/components/BytecodePanel.tsx
+++ b/web/src/components/BytecodePanel.tsx
@@ -1,0 +1,231 @@
+/**
+ * Bytecode disassembly view: shows the compiled instructions for the selected
+ * script, highlights the instruction at the current trace step's program
+ * counter, and draws jump arrows in a left gutter connecting goto/ifeq/ifne
+ * instructions to their target offsets.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { useStore, useCurrentStep } from '../store'
+import type { Instruction, Operand } from '../engine/types'
+import { opStyle, CATEGORY_STYLE } from '../theme'
+import { Panel, CountBadge, EmptyState } from './Panel'
+
+/** Fixed row height (px) — kept in sync with the row styling for arrow geometry. */
+const ROW_H = 22
+/** Width (px) of the left gutter reserved for jump arrows. */
+const GUTTER_W = 24
+
+/** Format an instruction's operand into a short display string. */
+function formatOperand(op: string, format: string, operand: Operand): string {
+  switch (format) {
+    case 'jump':
+      if (operand && typeof operand === 'object') {
+        return `-> @${operand.target}`
+      }
+      return ''
+    case 'const':
+      return typeof operand === 'string' ? operand : ''
+    case 'argc':
+      return typeof operand === 'number' ? `(${operand} arg${operand === 1 ? '' : 's'})` : ''
+    case 'incop':
+      return typeof operand === 'string' ? `(${operand})` : ''
+    default:
+      return ''
+  }
+}
+
+interface JumpArrow {
+  fromIndex: number
+  toIndex: number
+  back: boolean
+}
+
+export function BytecodePanel() {
+  const scripts = useStore((s) => s.result?.scripts) ?? []
+  const current = useCurrentStep()
+
+  // Track the selected script by its array index (TraceStep.script is an index).
+  const [selected, setSelected] = useState(0)
+
+  // Sync selection to the script of the current trace step.
+  useEffect(() => {
+    if (current && current.script >= 0 && current.script < scripts.length) {
+      setSelected(current.script)
+    }
+  }, [current, scripts.length])
+
+  // Clamp selection if scripts change underneath us.
+  const selectedIndex = selected < scripts.length ? selected : 0
+  const script = scripts[selectedIndex]
+  const bytecode = useMemo<Instruction[]>(() => script?.bytecode ?? [], [script])
+
+  // Map byte offset -> row index for the selected script (for jump targets).
+  const offsetToIndex = useMemo(() => {
+    const map = new Map<number, number>()
+    bytecode.forEach((ins, i) => map.set(ins.offset, i))
+    return map
+  }, [bytecode])
+
+  // Compute jump arrows for the selected script.
+  const arrows = useMemo<JumpArrow[]>(() => {
+    const out: JumpArrow[] = []
+    bytecode.forEach((ins, i) => {
+      if (ins.format === 'jump' && ins.operand && typeof ins.operand === 'object') {
+        const toIndex = offsetToIndex.get(ins.operand.target)
+        if (toIndex !== undefined) {
+          out.push({ fromIndex: i, toIndex, back: ins.operand.delta < 0 })
+        }
+      }
+    })
+    return out
+  }, [bytecode, offsetToIndex])
+
+  const isCurrentScript = current?.script === selectedIndex
+  const activeRef = useRef<HTMLDivElement | null>(null)
+
+  // Scroll the active instruction into view when it changes.
+  useEffect(() => {
+    if (isCurrentScript) {
+      activeRef.current?.scrollIntoView({ block: 'nearest' })
+    }
+  }, [isCurrentScript, current?.pc])
+
+  const arrowColor = opStyle('goto').hex
+
+  const legend = (
+    <div className="flex flex-wrap items-center gap-1">
+      {(Object.keys(CATEGORY_STYLE) as Array<keyof typeof CATEGORY_STYLE>).map((cat) => (
+        <span
+          key={cat}
+          className={clsx(
+            'rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none',
+            CATEGORY_STYLE[cat].chip,
+          )}
+        >
+          {CATEGORY_STYLE[cat].label}
+        </span>
+      ))}
+    </div>
+  )
+
+  if (!script || bytecode.length === 0) {
+    return (
+      <Panel
+        title="Bytecode"
+        subtitle="mo_emit.c / mocha.def — compiled instructions"
+      >
+        <EmptyState>No bytecode yet. Run a program to disassemble it.</EmptyState>
+      </Panel>
+    )
+  }
+
+  const svgHeight = bytecode.length * ROW_H
+
+  return (
+    <Panel
+      title="Bytecode"
+      subtitle="mo_emit.c / mocha.def — compiled instructions"
+      badge={<CountBadge>{bytecode.length}</CountBadge>}
+      actions={legend}
+      bodyClassName="flex flex-col"
+    >
+      {scripts.length > 1 && (
+        <div className="flex shrink-0 flex-wrap gap-1 border-b border-ink-600 bg-ink-800/60 px-2 py-1.5">
+          {scripts.map((s, i) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setSelected(i)}
+              className={clsx(
+                'rounded px-2 py-0.5 font-mono text-[11px] transition-colors',
+                i === selectedIndex
+                  ? 'bg-accent/20 text-accent-bright ring-1 ring-accent/40'
+                  : 'bg-ink-700 text-ink-300 hover:bg-ink-600 hover:text-ink-100',
+              )}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="relative min-h-0 flex-1 overflow-auto font-mono text-[12px]">
+        {/* Jump-arrow gutter overlay. */}
+        <svg
+          className="pointer-events-none absolute left-0 top-0"
+          width={GUTTER_W}
+          height={svgHeight}
+          style={{ overflow: 'visible' }}
+          aria-hidden
+        >
+          {arrows.map((arrow, idx) => {
+            const y1 = arrow.fromIndex * ROW_H + ROW_H / 2
+            const y2 = arrow.toIndex * ROW_H + ROW_H / 2
+            const xEdge = GUTTER_W - 3
+            const xBend = 6
+            // A simple rounded "bracket" connecting source to target.
+            const d = `M ${xEdge} ${y1} L ${xBend} ${y1} L ${xBend} ${y2} L ${xEdge} ${y2}`
+            return (
+              <g key={idx} stroke={arrowColor} fill="none" opacity={0.55}>
+                <path d={d} strokeWidth={1} />
+                {/* Arrowhead pointing into the target row. */}
+                <path
+                  d={`M ${xEdge} ${y2} l -4 -3 m 4 3 l -4 3`}
+                  strokeWidth={1}
+                />
+              </g>
+            )
+          })}
+        </svg>
+
+        <div style={{ paddingLeft: GUTTER_W }}>
+          {bytecode.map((ins, i) => {
+            const style = opStyle(ins.op)
+            const operandText = formatOperand(ins.op, ins.format, ins.operand)
+            const active = isCurrentScript && current?.pc === ins.offset
+            const isJump = ins.format === 'jump' && ins.operand && typeof ins.operand === 'object'
+            const back =
+              isJump && typeof ins.operand === 'object' && ins.operand !== null
+                ? ins.operand.delta < 0
+                : false
+            return (
+              <div
+                key={ins.offset}
+                ref={active ? activeRef : undefined}
+                className={clsx(
+                  'flex items-center gap-2 px-3 pr-3',
+                  active
+                    ? 'border-l-2 border-accent bg-accent/15'
+                    : 'border-l-2 border-transparent hover:bg-ink-700/40',
+                )}
+                style={{ height: ROW_H }}
+              >
+                <span className="w-12 shrink-0 text-right text-ink-500 tabular-nums">
+                  {String(ins.offset).padStart(5, '0')}
+                </span>
+                <span
+                  className="shrink-0 font-semibold"
+                  style={{ color: style.hex }}
+                >
+                  {ins.op}
+                </span>
+                {operandText && (
+                  <span className="truncate text-ink-300">{operandText}</span>
+                )}
+                {isJump && (
+                  <span
+                    className="ml-auto shrink-0 text-[10px] leading-none text-ink-500"
+                    title={back ? 'back-edge' : 'forward jump'}
+                  >
+                    {back ? '▲' : '▼'}
+                  </span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/components/CallStackPanel.tsx
+++ b/web/src/components/CallStackPanel.tsx
@@ -1,0 +1,186 @@
+/**
+ * Call stack visualizer. Reconstructs the chain of active function frames at
+ * the current trace step and renders them top-down (innermost first), so the
+ * shape of the running call stack is legible at a glance.
+ */
+import { useMemo } from 'react'
+import clsx from 'clsx'
+import { useStore, useCurrentStep } from '../store'
+import type { Datum, Frame, TraceStep } from '../engine/types'
+import { datumColor } from '../theme'
+import { Panel, CountBadge, EmptyState } from './Panel'
+
+/** A frame as rendered: depth + the function name and its captured data. */
+interface ChainFrame {
+  depth: number
+  fn: string
+  args: Datum[]
+  vars: Datum[]
+  /** True for the innermost / currently-executing frame. */
+  current: boolean
+}
+
+/**
+ * Walk backwards from the current step to find, for each depth level
+ * d = current.depth .. 1, the most recent step at exactly that depth and use
+ * its frame. Depth 0 is always the synthetic "<main>" frame at the bottom.
+ */
+function buildChain(
+  trace: TraceStep[],
+  stepIndex: number,
+  current: TraceStep,
+): ChainFrame[] {
+  const chain: ChainFrame[] = []
+
+  for (let level = current.depth; level >= 1; level--) {
+    let found: Frame | null = null
+    for (let i = stepIndex; i >= 0; i--) {
+      const s = trace[i]
+      if (s.depth === level && s.frame) {
+        found = s.frame
+        break
+      }
+    }
+    chain.push({
+      depth: level,
+      fn: found?.fn ?? '(anonymous)',
+      args: found?.args ?? [],
+      vars: found?.vars ?? [],
+      current: level === current.depth,
+    })
+  }
+
+  // Bottom of the stack: the top-level program.
+  chain.push({
+    depth: 0,
+    fn: '<main>',
+    args: [],
+    vars: [],
+    current: current.depth === 0,
+  })
+
+  return chain
+}
+
+function ValueChip({ datum }: { datum: Datum }) {
+  const color = datumColor(datum.type)
+  return (
+    <span
+      className="inline-flex max-w-full items-center gap-1 rounded border border-ink-600 bg-ink-900/50 px-1.5 py-0.5 font-mono text-[11px]"
+      title={`${datum.type}: ${datum.value}`}
+    >
+      <span
+        className="h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      <span className="truncate" style={{ color }}>
+        {datum.value}
+      </span>
+    </span>
+  )
+}
+
+function FrameCard({ frame }: { frame: ChainFrame }) {
+  const { current } = frame
+  return (
+    <li
+      className={clsx(
+        'rounded-lg border px-3 py-2 transition-colors',
+        current
+          ? 'border-accent/60 bg-accent/10'
+          : 'border-ink-600 bg-ink-800/60',
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={clsx(
+            'truncate font-mono text-sm font-semibold',
+            current ? 'text-accent-bright' : 'text-ink-100',
+          )}
+        >
+          {frame.fn}
+        </span>
+        <span
+          className={clsx(
+            'shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+            current
+              ? 'border-accent/40 text-accent'
+              : 'border-ink-600 text-ink-300',
+          )}
+        >
+          depth {frame.depth}
+        </span>
+      </div>
+
+      {frame.args.length > 0 && (
+        <div className="mt-2">
+          <div className="mb-1 text-[10px] uppercase tracking-wide text-ink-400">
+            args
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {frame.args.map((d, i) => (
+              <ValueChip key={i} datum={d} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {frame.vars.length > 0 && (
+        <div className="mt-2">
+          <div className="mb-1 flex items-center gap-1 text-[10px] uppercase tracking-wide text-ink-400">
+            <span>vars</span>
+            <CountBadge>{frame.vars.length}</CountBadge>
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {frame.vars.map((d, i) => (
+              <ValueChip key={i} datum={d} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {frame.depth > 0 &&
+        frame.args.length === 0 &&
+        frame.vars.length === 0 && (
+          <div className="mt-1 text-[11px] italic text-ink-400">
+            no locals
+          </div>
+        )}
+    </li>
+  )
+}
+
+export function CallStackPanel() {
+  const result = useStore((s) => s.result)
+  const stepIndex = useStore((s) => s.stepIndex)
+  const step = useCurrentStep()
+
+  const chain = useMemo<ChainFrame[]>(() => {
+    if (!result || !step || stepIndex < 0) return []
+    return buildChain(result.trace, stepIndex, step)
+  }, [result, step, stepIndex])
+
+  return (
+    <Panel
+      title="Call stack"
+      subtitle="active function frames"
+      badge={chain.length > 0 ? <CountBadge>{chain.length}</CountBadge> : null}
+      bodyClassName="p-3"
+    >
+      {chain.length === 0 ? (
+        <EmptyState>
+          {result
+            ? 'Step through the trace to inspect call frames.'
+            : 'Run a program to inspect the call stack.'}
+        </EmptyState>
+      ) : (
+        <ol className="flex flex-col gap-2">
+          {chain.map((frame) => (
+            <FrameCard key={frame.depth} frame={frame} />
+          ))}
+        </ol>
+      )}
+    </Panel>
+  )
+}

--- a/web/src/components/ConsolePanel.tsx
+++ b/web/src/components/ConsolePanel.tsx
@@ -1,0 +1,124 @@
+/**
+ * Console output panel: shows print() output, the final result value,
+ * parse/runtime errors with a caret under the offending column, and run stats.
+ */
+import { useStore } from '../store'
+import { datumColor } from '../theme'
+import type { MochaError } from '../engine/types'
+import { Panel, CountBadge, EmptyState } from './Panel'
+
+/** Renders a Mocha error block with the source line and a caret marker. */
+function ErrorBlock({ error }: { error: MochaError }) {
+  // error.col is 1-based; clamp so the caret never goes negative.
+  const caretPad = Math.max(0, error.col - 1)
+  const caret = `${' '.repeat(caretPad)}^`
+  return (
+    <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-red-200">
+      <div className="flex items-baseline gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-red-300">
+          Error
+        </span>
+        <span className="text-[11px] text-red-300/80">
+          line {error.line}:{error.col}
+        </span>
+      </div>
+      <p className="mt-1 text-sm font-medium text-red-100">{error.message}</p>
+      {error.linebuf !== '' && (
+        <pre className="mt-2 overflow-x-auto whitespace-pre font-mono text-xs leading-tight text-red-200/90">
+          {error.linebuf}
+          {'\n'}
+          <span className="text-accent">{caret}</span>
+        </pre>
+      )}
+    </div>
+  )
+}
+
+export function ConsolePanel() {
+  const result = useStore((s) => s.result)
+  const status = useStore((s) => s.status)
+  const loadError = useStore((s) => s.loadError)
+
+  if (!result && status === 'idle' && !loadError) {
+    return (
+      <Panel title="Console" subtitle="print() output & result">
+        <EmptyState>Press Run to execute with the 1995 engine.</EmptyState>
+      </Panel>
+    )
+  }
+
+  const output = result?.output ?? ''
+  const finalValue = result?.result ?? null
+  const stats = result?.stats ?? null
+
+  return (
+    <Panel
+      title="Console"
+      subtitle="print() output & result"
+      badge={
+        result?.truncated ? (
+          <span className="rounded-full border border-amber-500/40 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-200">
+            trace truncated
+          </span>
+        ) : undefined
+      }
+    >
+      <div className="flex min-h-0 flex-col gap-3 p-3">
+        {/* print() output */}
+        {output !== '' ? (
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-ink-100">
+            {output}
+          </pre>
+        ) : (
+          <p className="font-mono text-xs italic text-ink-400">(no output)</p>
+        )}
+
+        {/* engine load/run failure */}
+        {loadError && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-red-200">
+            <div className="text-xs font-semibold uppercase tracking-wide text-red-300">
+              Engine error
+            </div>
+            <p className="mt-1 whitespace-pre-wrap break-words text-sm font-medium text-red-100">
+              {loadError}
+            </p>
+          </div>
+        )}
+
+        {/* parse / runtime error */}
+        {result?.error && <ErrorBlock error={result.error} />}
+
+        {/* final value */}
+        {finalValue && (
+          <div className="flex items-center gap-2 rounded-lg border border-ink-600 bg-ink-700/40 px-3 py-2 font-mono text-xs">
+            <span className="text-ink-400">⇒</span>
+            <span
+              className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: datumColor(finalValue.type) }}
+              aria-hidden
+            />
+            <span className="min-w-0 break-all text-ink-100">
+              {finalValue.value}
+            </span>
+            <span className="ml-auto shrink-0 text-ink-400">
+              : {finalValue.type}
+            </span>
+          </div>
+        )}
+
+        {/* run stats */}
+        {stats && (
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-ink-300">
+            <span className="flex items-center gap-1">
+              <CountBadge>{stats.steps}</CountBadge> steps
+            </span>
+            <span className="flex items-center gap-1">
+              <CountBadge>{stats.scripts}</CountBadge>{' '}
+              {stats.scripts === 1 ? 'script' : 'scripts'}
+            </span>
+          </div>
+        )}
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/components/DebuggerControls.tsx
+++ b/web/src/components/DebuggerControls.tsx
@@ -1,0 +1,155 @@
+/**
+ * Debugger transport bar: a compact control strip that drives the single
+ * "current step" of the execution trace. The actual play interval lives in a
+ * separate usePlayLoop hook; here play()/pause() merely flip state.
+ */
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+import { useStore, useCurrentStep } from '../store'
+
+interface TransportButtonProps {
+  onClick: () => void
+  label: string
+  disabled?: boolean
+  active?: boolean
+  /** Visually emphasize (used for play/pause). */
+  primary?: boolean
+  children: ReactNode
+}
+
+function TransportButton({
+  onClick,
+  label,
+  disabled,
+  active,
+  primary,
+  children,
+}: TransportButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={label}
+      aria-label={label}
+      className={clsx(
+        'inline-flex h-8 min-w-8 items-center justify-center rounded-md border px-2 text-sm font-medium leading-none transition-colors',
+        'focus:outline-none focus-visible:ring-1 focus-visible:ring-accent',
+        'disabled:cursor-not-allowed disabled:opacity-40',
+        primary
+          ? active
+            ? 'border-accent bg-accent text-ink-900 hover:bg-accent-bright'
+            : 'border-accent/60 bg-accent/15 text-accent hover:bg-accent/25'
+          : 'border-ink-600 bg-ink-700/60 text-ink-200 hover:border-ink-500 hover:bg-ink-700 hover:text-ink-100',
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function DebuggerControls() {
+  const result = useStore((s) => s.result)
+  const stepIndex = useStore((s) => s.stepIndex)
+  const playing = useStore((s) => s.playing)
+  const speed = useStore((s) => s.speed)
+
+  const stepBack = useStore((s) => s.stepBack)
+  const stepForward = useStore((s) => s.stepForward)
+  const stepOver = useStore((s) => s.stepOver)
+  const togglePlay = useStore((s) => s.togglePlay)
+  const reset = useStore((s) => s.reset)
+  const setStep = useStore((s) => s.setStep)
+  const setSpeed = useStore((s) => s.setSpeed)
+
+  const current = useCurrentStep()
+  const trace = result?.trace ?? []
+  const total = trace.length
+  const hasTrace = total > 0
+  const max = Math.max(0, total - 1)
+  const sliderValue = stepIndex >= 0 ? stepIndex : 0
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-ink-600 bg-ink-800/80 px-3 py-2.5 backdrop-blur">
+      {/* Transport buttons + readout */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="flex items-center gap-1">
+          <TransportButton onClick={reset} label="Reset to start" disabled={!hasTrace}>
+            ⟲
+          </TransportButton>
+          <TransportButton onClick={stepBack} label="Step back" disabled={!hasTrace}>
+            ◀
+          </TransportButton>
+          <TransportButton
+            onClick={togglePlay}
+            label={playing ? 'Pause' : 'Play'}
+            disabled={!hasTrace}
+            active={playing}
+            primary
+          >
+            {playing ? '⏸' : '▶'}
+          </TransportButton>
+          <TransportButton onClick={stepForward} label="Step forward" disabled={!hasTrace}>
+            ▌▶
+          </TransportButton>
+          <TransportButton onClick={stepOver} label="Step over" disabled={!hasTrace}>
+            ⤼
+          </TransportButton>
+        </div>
+
+        {hasTrace ? (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 font-mono text-[11px] text-ink-300">
+            <span className="text-ink-200">
+              step{' '}
+              <span className="tabular-nums text-ink-100">{sliderValue + 1}</span>
+              {' / '}
+              <span className="tabular-nums">{total}</span>
+            </span>
+            <span>
+              line{' '}
+              <span className="tabular-nums text-ink-100">{current?.line ?? '—'}</span>
+            </span>
+            <span>
+              op <span className="text-accent">{current?.op ?? '—'}</span>
+            </span>
+          </div>
+        ) : (
+          <span className="text-[11px] text-ink-400">
+            Run a program to start debugging.
+          </span>
+        )}
+
+        {/* Speed control, pushed to the right */}
+        <label className="ml-auto flex items-center gap-2 text-[11px] text-ink-300">
+          <span className="select-none">speed</span>
+          <input
+            type="range"
+            min={1}
+            max={30}
+            step={1}
+            value={speed}
+            onChange={(e) => setSpeed(Number(e.target.value))}
+            className="h-1.5 w-24 cursor-pointer accent-accent"
+            aria-label="Playback speed (steps per second)"
+          />
+          <span className="w-12 shrink-0 text-right font-mono tabular-nums text-ink-100">
+            x{speed}/s
+          </span>
+        </label>
+      </div>
+
+      {/* Scrubber */}
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={1}
+        value={sliderValue}
+        disabled={!hasTrace}
+        onChange={(e) => setStep(Number(e.target.value))}
+        className="h-2 w-full cursor-pointer accent-accent disabled:cursor-not-allowed disabled:opacity-40"
+        aria-label="Trace scrubber"
+      />
+    </div>
+  )
+}

--- a/web/src/components/EditorPane.tsx
+++ b/web/src/components/EditorPane.tsx
@@ -1,0 +1,109 @@
+/** Source code editor with debug/error line highlighting. */
+import { useEffect, useRef } from 'react'
+import CodeMirror from '@uiw/react-codemirror'
+import { javascript } from '@codemirror/lang-javascript'
+import { EditorView, Decoration, type DecorationSet } from '@codemirror/view'
+import { StateField, StateEffect, type EditorState, type Extension, type Range } from '@codemirror/state'
+import { Panel } from './Panel'
+import { useStore, useCurrentStep } from '../store'
+
+/** Lines to highlight, 1-based. 0/undefined means none. */
+interface HighlightLines {
+  current: number | undefined
+  error: number | undefined
+}
+
+/** Effect carrying the new set of lines to highlight. */
+const setHighlight = StateEffect.define<HighlightLines>()
+
+const currentLineDeco = Decoration.line({ class: 'cm-current-line-debug' })
+const errorLineDeco = Decoration.line({ class: 'cm-error-line' })
+
+/** Build a decoration set for the given lines, guarded against out-of-range. */
+function buildDecorations(state: EditorState, lines: HighlightLines): DecorationSet {
+  const { doc } = state
+  const ranges: Array<Range<Decoration>> = []
+
+  const add = (line: number | undefined, deco: Decoration): void => {
+    if (!line || line < 1 || line > doc.lines) return
+    const pos = doc.line(line).from
+    ranges.push(deco.range(pos))
+  }
+
+  // Error first so it sorts before current at the same position if needed.
+  add(lines.error, errorLineDeco)
+  add(lines.current, currentLineDeco)
+  // Decoration.set requires sorted-by-from ranges.
+  ranges.sort((a, b) => a.from - b.from)
+  return Decoration.set(ranges, true)
+}
+
+/** StateField holding the active line decorations. */
+const highlightField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none
+  },
+  update(deco, tr) {
+    let next = deco.map(tr.changes)
+    for (const effect of tr.effects) {
+      if (effect.is(setHighlight)) {
+        next = buildDecorations(tr.state, effect.value)
+      }
+    }
+    return next
+  },
+  provide: (f) => EditorView.decorations.from(f),
+})
+
+const extensions: Extension[] = [javascript(), highlightField]
+
+export function EditorPane() {
+  const code = useStore((s) => s.code)
+  const setCode = useStore((s) => s.setCode)
+  const currentLine = useCurrentStep()?.line
+  const errorLine = useStore((s) => s.result?.error?.line)
+
+  const viewRef = useRef<EditorView | null>(null)
+
+  // Push highlight lines into the editor whenever they change.
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    view.dispatch({
+      effects: setHighlight.of({ current: currentLine, error: errorLine }),
+    })
+  }, [currentLine, errorLine])
+
+  return (
+    <Panel
+      title="Source"
+      subtitle="JavaScript 1.1 (Mocha) · edit & Run"
+      className="h-full"
+      bodyClassName="p-0"
+    >
+      <div className="h-full min-h-0">
+        <CodeMirror
+          value={code}
+          onChange={(v) => setCode(v)}
+          theme="dark"
+          height="100%"
+          extensions={extensions}
+          basicSetup={{
+            lineNumbers: true,
+            foldGutter: false,
+            highlightActiveLine: false,
+          }}
+          onCreateEditor={(view) => {
+            viewRef.current = view
+            // Apply any current highlight immediately on mount.
+            view.dispatch({
+              effects: setHighlight.of({ current: currentLine, error: errorLine }),
+            })
+          }}
+          className="h-full text-[13px]"
+          style={{ height: '100%' }}
+        />
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/components/Panel.tsx
+++ b/web/src/components/Panel.tsx
@@ -1,0 +1,71 @@
+/** Shared titled panel container used by every visualization pane. */
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+
+interface PanelProps {
+  title: string
+  /** Short hint shown under the title. */
+  subtitle?: string
+  /** Right-aligned controls in the header. */
+  actions?: ReactNode
+  /** Small count/badge shown next to the title. */
+  badge?: ReactNode
+  className?: string
+  bodyClassName?: string
+  children: ReactNode
+}
+
+export function Panel({
+  title,
+  subtitle,
+  actions,
+  badge,
+  className,
+  bodyClassName,
+  children,
+}: PanelProps) {
+  return (
+    <section
+      className={clsx(
+        'flex min-h-0 flex-col overflow-hidden rounded-xl border border-ink-600 bg-ink-800/60 backdrop-blur',
+        className,
+      )}
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-ink-600 bg-ink-700/50 px-3 py-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="truncate text-sm font-semibold tracking-wide text-ink-100">
+              {title}
+            </h2>
+            {badge}
+          </div>
+          {subtitle && (
+            <p className="truncate text-[11px] text-ink-300">{subtitle}</p>
+          )}
+        </div>
+        {actions && <div className="flex shrink-0 items-center gap-1">{actions}</div>}
+      </header>
+      <div className={clsx('min-h-0 flex-1 overflow-auto', bodyClassName)}>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+/** A small rounded count badge. */
+export function CountBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-ink-600 px-2 py-0.5 text-[10px] font-medium text-ink-200">
+      {children}
+    </span>
+  )
+}
+
+/** Empty-state placeholder for panels with no data yet. */
+export function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-center text-sm text-ink-400">
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/StackPanel.tsx
+++ b/web/src/components/StackPanel.tsx
@@ -1,0 +1,97 @@
+/** Value-stack visualizer: shows the operand stack at the current trace step. */
+import { useCurrentStep } from '../store'
+import { datumColor } from '../theme'
+import type { Datum } from '../engine/types'
+import { Panel, CountBadge, EmptyState } from './Panel'
+
+interface CellProps {
+  datum: Datum
+  /** Stack index bottom→top (0 = bottom). Used as the animation key. */
+  index: number
+  isTop: boolean
+}
+
+function StackCell({ datum, index, isTop }: CellProps) {
+  const color = datumColor(datum.type)
+  return (
+    <div
+      key={index}
+      className="animate-pop-in flex items-stretch gap-2 overflow-hidden rounded-lg border border-ink-600 bg-ink-700/50"
+    >
+      <span
+        className="w-1.5 shrink-0 rounded-l-lg"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-3 py-1.5 pr-2.5">
+        <span
+          className="truncate font-mono text-sm text-ink-100"
+          style={{ color }}
+          title={datum.value}
+        >
+          {datum.value}
+        </span>
+        <span className="flex shrink-0 items-center gap-1.5">
+          {isTop && (
+            <span className="text-[10px] font-medium tracking-wide text-accent">
+              ← top
+            </span>
+          )}
+          <span className="rounded bg-ink-600 px-1.5 py-0.5 font-mono text-[10px] text-ink-300">
+            {datum.type}
+          </span>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function StackPanel() {
+  const step = useCurrentStep()
+  const stack: Datum[] = step?.stack ?? []
+
+  if (!step) {
+    return (
+      <Panel title="Value stack" subtitle="operand stack at current step">
+        <EmptyState>Run a program and step through it to inspect the operand stack.</EmptyState>
+      </Panel>
+    )
+  }
+
+  // Render top-of-stack first: stack is bottom→top, so reverse.
+  const cells = stack
+    .map((datum, index) => ({ datum, index }))
+    .reverse()
+
+  return (
+    <Panel
+      title="Value stack"
+      subtitle="operand stack at current step"
+      badge={<CountBadge>{stack.length}</CountBadge>}
+      bodyClassName="flex flex-col"
+    >
+      <div className="border-b border-ink-600 px-3 py-2 text-[11px] text-ink-300">
+        depth {step.depth} · about to run{' '}
+        <span className="font-mono text-ink-100">'{step.op}'</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {stack.length === 0 ? (
+          <div className="py-6 text-center font-mono text-xs text-ink-400">
+            (empty stack)
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            {cells.map(({ datum, index }, renderPos) => (
+              <StackCell
+                key={index}
+                datum={datum}
+                index={index}
+                isTop={renderPos === 0}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/components/TokensPanel.tsx
+++ b/web/src/components/TokensPanel.tsx
@@ -1,0 +1,83 @@
+/** Scanner output: the raw token stream produced by mo_scan.c, rendered as
+ *  colour-coded chips with a group legend. */
+import { useStore } from '../store'
+import type { Token } from '../engine/types'
+import { TOKEN_STYLE, tokenStyle, type TokenGroup } from '../theme'
+import { Panel, CountBadge, EmptyState } from './Panel'
+
+/** Order of groups in the legend (kept stable / readable). */
+const LEGEND_GROUPS: TokenGroup[] = [
+  'keyword',
+  'identifier',
+  'number',
+  'string',
+  'operator',
+  'punct',
+  'primary',
+]
+
+function Legend() {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-ink-600 bg-ink-800/40 px-3 py-2">
+      {LEGEND_GROUPS.map((group) => {
+        const style = TOKEN_STYLE[group]
+        return (
+          <span
+            key={group}
+            className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-ink-300"
+          >
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: style.hex }}
+              aria-hidden
+            />
+            {style.label}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+function TokenChip({ token }: { token: Token }) {
+  const style = tokenStyle(token.type)
+  const hasText = token.text.length > 0
+  return (
+    <span
+      title={`${token.type} @ ${token.line}:${token.col}`}
+      className={`inline-flex max-w-full items-center rounded-md border px-1.5 py-0.5 font-mono text-xs leading-none ${style.chip}`}
+    >
+      {hasText ? (
+        <span className="truncate whitespace-pre">{token.text}</span>
+      ) : (
+        <span className="italic opacity-50">{token.type}</span>
+      )}
+    </span>
+  )
+}
+
+export function TokensPanel() {
+  const tokens = useStore((s) => s.result?.tokens) ?? []
+
+  return (
+    <Panel
+      title="Tokens"
+      subtitle="mo_scan.c — scanner output"
+      badge={<CountBadge>{tokens.length}</CountBadge>}
+      bodyClassName="flex flex-col"
+    >
+      {tokens.length === 0 ? (
+        <EmptyState>No tokens yet — run some code to see the scanner output.</EmptyState>
+      ) : (
+        <>
+          <Legend />
+          <div className="flex min-h-0 flex-1 flex-wrap content-start gap-1.5 overflow-auto p-3">
+            {tokens.map((token) => (
+              <TokenChip key={token.index} token={token} />
+            ))}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/web/src/components/Toolbar.tsx
+++ b/web/src/components/Toolbar.tsx
@@ -1,0 +1,190 @@
+/** Top application bar: wordmark, examples picker, Run button, status pill. */
+import { useEffect, type ChangeEvent } from 'react'
+import clsx from 'clsx'
+import { useStore, type RunStatus } from '../store'
+import { EXAMPLES } from '../engine/examples'
+
+const STATUS_STYLE: Record<RunStatus, { dot: string; chip: string; label: string }> = {
+  idle: {
+    dot: 'bg-ink-400',
+    chip: 'bg-ink-700 text-ink-300 border-ink-600',
+    label: 'Idle',
+  },
+  running: {
+    dot: 'bg-accent animate-pulse',
+    chip: 'bg-accent/15 text-accent-bright border-accent/40',
+    label: 'Running',
+  },
+  done: {
+    dot: 'bg-emerald-400',
+    chip: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/40',
+    label: 'Done',
+  },
+  error: {
+    dot: 'bg-red-400',
+    chip: 'bg-red-500/15 text-red-300 border-red-500/40',
+    label: 'Error',
+  },
+}
+
+function Spinner() {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin text-current"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 0 1 8-8V0C5.4 0 0 5.4 0 12h4z"
+      />
+    </svg>
+  )
+}
+
+export function Toolbar() {
+  const status = useStore((s) => s.status)
+  const result = useStore((s) => s.result)
+  const setCode = useStore((s) => s.setCode)
+  const run = useStore((s) => s.run)
+
+  const isRunning = status === 'running'
+
+  // Cmd/Ctrl+Enter runs the current source.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault()
+        if (useStore.getState().status !== 'running') void useStore.getState().run()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const onPickExample = (e: ChangeEvent<HTMLSelectElement>) => {
+    const ex = EXAMPLES.find((x) => x.id === e.target.value)
+    if (!ex) return
+    setCode(ex.code)
+    void run()
+    e.target.selectedIndex = 0
+  }
+
+  const statusStyle = STATUS_STYLE[status]
+
+  return (
+    <header className="flex items-center gap-3 border-b border-ink-600 bg-ink-800 px-4 py-2.5">
+      {/* Wordmark */}
+      <div className="flex min-w-0 shrink-0 flex-col leading-none">
+        <span className="text-base font-bold tracking-tight text-accent">
+          ☕ Mocha 1995
+        </span>
+        <span className="mt-0.5 text-[10px] uppercase tracking-wide text-ink-400">
+          Engine Playground &amp; Debugger
+        </span>
+      </div>
+
+      <div className="ml-2 hidden h-6 w-px shrink-0 bg-ink-600 sm:block" />
+
+      {/* Examples dropdown */}
+      <div className="relative shrink-0">
+        <select
+          aria-label="Load an example program"
+          defaultValue=""
+          onChange={onPickExample}
+          disabled={isRunning}
+          className="appearance-none rounded-lg border border-ink-600 bg-ink-700 py-1.5 pl-3 pr-8 text-xs font-medium text-ink-100 transition-colors hover:border-ink-500 focus:border-accent focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <option value="" disabled>
+            Examples…
+          </option>
+          {EXAMPLES.map((ex) => (
+            <option key={ex.id} value={ex.id} className="bg-ink-800 text-ink-100">
+              {ex.title}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[10px] text-ink-400">
+          ▼
+        </span>
+      </div>
+
+      {/* Run button */}
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={isRunning}
+        title="Run (⌘/Ctrl + Enter)"
+        className={clsx(
+          'inline-flex shrink-0 items-center gap-2 rounded-lg px-4 py-1.5 text-xs font-semibold transition-colors',
+          isRunning
+            ? 'cursor-not-allowed bg-mocha-700 text-mocha-200'
+            : 'bg-accent text-ink-900 hover:bg-accent-bright',
+        )}
+      >
+        {isRunning ? (
+          <>
+            <Spinner />
+            Running…
+          </>
+        ) : (
+          <>Run ▶</>
+        )}
+      </button>
+
+      {/* Status pill */}
+      <div
+        className={clsx(
+          'inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-medium',
+          statusStyle.chip,
+        )}
+      >
+        <span className={clsx('h-1.5 w-1.5 rounded-full', statusStyle.dot)} />
+        <span>{statusStyle.label}</span>
+        {result && (
+          <span className="font-mono text-current/80">
+            {result.stats.steps.toLocaleString()} steps
+          </span>
+        )}
+        {result?.truncated && (
+          <span
+            title="Trace was truncated — increase the step limit to see more"
+            className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300"
+          >
+            truncated
+          </span>
+        )}
+      </div>
+
+      <div className="ml-auto" />
+
+      {/* GitHub link */}
+      <a
+        href="https://github.com/doodlewind/mocha1995"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="View source on GitHub"
+        className="shrink-0 rounded-lg p-1.5 text-ink-400 transition-colors hover:bg-ink-700 hover:text-ink-100"
+      >
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+        </svg>
+      </a>
+    </header>
+  )
+}

--- a/web/src/components/charts/OpcodeChart.tsx
+++ b/web/src/components/charts/OpcodeChart.tsx
@@ -1,0 +1,135 @@
+/** Opcode frequency bar chart: tallies executed bytecodes across the trace. */
+import { useMemo } from 'react'
+import clsx from 'clsx'
+import { useStore, useCurrentStep } from '../../store'
+import {
+  opStyle,
+  opCategory,
+  CATEGORY_STYLE,
+  type OpCategory,
+} from '../../theme'
+import { Panel, CountBadge, EmptyState } from '../Panel'
+
+interface OpCount {
+  op: string
+  count: number
+}
+
+const CATEGORY_ORDER: OpCategory[] = [
+  'load',
+  'arith',
+  'logic',
+  'control',
+  'call',
+  'store',
+  'member',
+  'stack',
+  'other',
+]
+
+export function OpcodeChart() {
+  const result = useStore((s) => s.result)
+  const current = useCurrentStep()
+  const trace = result?.trace ?? []
+
+  const { rows, max, total, categoryTotals } = useMemo(() => {
+    const counts = new Map<string, number>()
+    const cats = new Map<OpCategory, number>()
+    for (const step of trace) {
+      counts.set(step.op, (counts.get(step.op) ?? 0) + 1)
+      const cat = opCategory(step.op)
+      cats.set(cat, (cats.get(cat) ?? 0) + 1)
+    }
+    const rows: OpCount[] = Array.from(counts, ([op, count]) => ({ op, count }))
+    rows.sort((a, b) => b.count - a.count || a.op.localeCompare(b.op))
+    const max = rows.length > 0 ? rows[0].count : 0
+    const total = trace.length
+    return { rows, max, total, categoryTotals: cats }
+  }, [trace])
+
+  const currentOp = current?.op ?? null
+
+  return (
+    <Panel
+      title="Opcode profile"
+      subtitle="bytecodes executed, by frequency"
+      badge={rows.length > 0 ? <CountBadge>{rows.length}</CountBadge> : undefined}
+    >
+      {rows.length === 0 ? (
+        <EmptyState>No bytecodes executed yet. Run a script to profile it.</EmptyState>
+      ) : (
+        <div className="flex h-full min-h-0 flex-col">
+          {/* Category legend with per-category totals. */}
+          <div className="flex flex-wrap gap-1.5 border-b border-ink-700 px-3 py-2">
+            {CATEGORY_ORDER.map((cat) => {
+              const n = categoryTotals.get(cat) ?? 0
+              if (n === 0) return null
+              const style = CATEGORY_STYLE[cat]
+              return (
+                <span
+                  key={cat}
+                  className={clsx(
+                    'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                    style.chip,
+                  )}
+                >
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: style.hex }}
+                  />
+                  {style.label}
+                  <span className="font-mono tabular-nums opacity-80">{n}</span>
+                </span>
+              )
+            })}
+          </div>
+
+          {/* Bars. */}
+          <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
+            <ul className="flex flex-col gap-1">
+              {rows.map(({ op, count }) => {
+                const style = opStyle(op)
+                const pct = max > 0 ? (count / max) * 100 : 0
+                const share = total > 0 ? (count / total) * 100 : 0
+                const isCurrent = op === currentOp
+                return (
+                  <li
+                    key={op}
+                    className={clsx(
+                      'flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors',
+                      isCurrent && 'bg-ink-700/60 ring-1 ring-accent',
+                    )}
+                  >
+                    <span
+                      className="w-20 shrink-0 truncate text-right font-mono text-xs"
+                      style={{ color: style.hex }}
+                      title={op}
+                    >
+                      {op}
+                    </span>
+                    <div className="relative h-4 min-w-0 flex-1 overflow-hidden rounded-sm bg-ink-700/40">
+                      <div
+                        className="h-full rounded-sm transition-[width] duration-300"
+                        style={{
+                          width: `${pct}%`,
+                          backgroundColor: style.hex,
+                          opacity: isCurrent ? 1 : 0.78,
+                        }}
+                      />
+                    </div>
+                    <span
+                      className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-ink-200"
+                      title={`${share.toFixed(1)}% of executed bytecodes`}
+                    >
+                      {count}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </div>
+      )}
+    </Panel>
+  )
+}

--- a/web/src/components/charts/PipelinePanel.tsx
+++ b/web/src/components/charts/PipelinePanel.tsx
@@ -1,0 +1,218 @@
+/**
+ * Compiler-pipeline diagram: visualises how Mocha turns source text into
+ * results, with a live metric on each stage that updates after every run.
+ */
+import { useMemo } from 'react'
+import clsx from 'clsx'
+import { useStore } from '../../store'
+import type { RunResult } from '../../engine/types'
+import { Panel } from '../Panel'
+
+type StageKey =
+  | 'source'
+  | 'scanner'
+  | 'tokens'
+  | 'parser'
+  | 'bytecode'
+  | 'interpreter'
+  | 'output'
+
+interface Stage {
+  key: StageKey
+  icon: string
+  title: string
+  /** Primary live metric, big. */
+  metric: string
+  /** Optional secondary line under the metric. */
+  detail?: string
+  /** Accent stages carry data; muted stages are pure transforms. */
+  kind: 'data' | 'transform'
+}
+
+/** Count source lines (at least 1 for a non-empty string). */
+function countLines(code: string): number {
+  if (code.length === 0) return 0
+  return code.split('\n').length
+}
+
+/** Count printed output lines, ignoring a single trailing newline. */
+function countOutputLines(output: string): number {
+  if (output.length === 0) return 0
+  const trimmed = output.endsWith('\n') ? output.slice(0, -1) : output
+  return trimmed.length === 0 ? 0 : trimmed.split('\n').length
+}
+
+function buildStages(code: string, result: RunResult | null): Stage[] {
+  const lines = countLines(code)
+  const tokenCount = result?.tokens.length ?? 0
+  const scripts = result?.scripts ?? []
+  const instrCount = scripts.reduce((sum, s) => sum + s.bytecode.length, 0)
+  const steps = result?.stats.steps ?? 0
+  const maxDepth = result?.trace.reduce((m, t) => Math.max(m, t.depth), 0) ?? 0
+  const outLines = result ? countOutputLines(result.output) : 0
+
+  return [
+    {
+      key: 'source',
+      icon: '📄',
+      title: 'Source',
+      metric: `${lines}`,
+      detail: lines === 1 ? 'line' : 'lines',
+      kind: 'data',
+    },
+    {
+      key: 'scanner',
+      icon: '🔍',
+      title: 'Scanner',
+      metric: 'lex',
+      detail: 'text → tokens',
+      kind: 'transform',
+    },
+    {
+      key: 'tokens',
+      icon: '🔤',
+      title: 'Tokens',
+      metric: `${tokenCount}`,
+      detail: 'tokens',
+      kind: 'data',
+    },
+    {
+      key: 'parser',
+      icon: '🌳',
+      title: 'Parser / Emitter',
+      metric: 'compile',
+      detail: 'tokens → ops',
+      kind: 'transform',
+    },
+    {
+      key: 'bytecode',
+      icon: '🧱',
+      title: 'Bytecode',
+      metric: `${instrCount}`,
+      detail: `${scripts.length} ${scripts.length === 1 ? 'script' : 'scripts'}`,
+      kind: 'data',
+    },
+    {
+      key: 'interpreter',
+      icon: '⚙️',
+      title: 'Interpreter',
+      metric: `${steps}`,
+      detail: `steps · depth ${maxDepth}`,
+      kind: 'transform',
+    },
+    {
+      key: 'output',
+      icon: '📤',
+      title: 'Output',
+      metric: `${outLines}`,
+      detail: outLines === 1 ? 'line' : 'lines',
+      kind: 'data',
+    },
+  ]
+}
+
+/** Which stage is currently "in flight" while a run is executing. */
+const RUNNING_STAGE: StageKey = 'interpreter'
+
+interface StageCardProps {
+  stage: Stage
+  active: boolean
+  hasResult: boolean
+}
+
+function StageCard({ stage, active, hasResult }: StageCardProps) {
+  const isData = stage.kind === 'data'
+  return (
+    <div
+      className={clsx(
+        'relative flex w-full flex-col items-center gap-1 rounded-lg border px-3 py-3 text-center transition-colors sm:w-28',
+        active
+          ? 'animate-pulse border-accent bg-accent/15'
+          : isData
+            ? 'border-mocha-700/60 bg-mocha-900/40'
+            : 'border-ink-600 bg-ink-700/40',
+      )}
+    >
+      <span className="text-xl leading-none" aria-hidden>
+        {stage.icon}
+      </span>
+      <span className="text-[11px] font-semibold tracking-wide text-ink-100">
+        {stage.title}
+      </span>
+      <span
+        className={clsx(
+          'font-mono text-lg font-bold leading-none',
+          isData
+            ? hasResult
+              ? 'text-accent-bright'
+              : 'text-ink-400'
+            : 'text-mocha-200',
+        )}
+      >
+        {stage.metric}
+      </span>
+      {stage.detail && (
+        <span className="text-[10px] leading-tight text-ink-400">
+          {stage.detail}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/** Directional connector between stage cards. */
+function Arrow() {
+  return (
+    <div className="flex shrink-0 items-center justify-center text-ink-500">
+      {/* horizontal on >= sm, vertical (rotated) when stages wrap */}
+      <span className="hidden sm:inline" aria-hidden>
+        →
+      </span>
+      <span className="sm:hidden" aria-hidden>
+        ↓
+      </span>
+    </div>
+  )
+}
+
+export function PipelinePanel() {
+  const code = useStore((s) => s.code)
+  const result = useStore((s) => s.result)
+  const status = useStore((s) => s.status)
+
+  const stages = useMemo(() => buildStages(code, result), [code, result])
+  const running = status === 'running'
+  const hasResult = result !== null
+
+  return (
+    <Panel
+      title="Engine pipeline"
+      subtitle="how Mocha turns source into results"
+    >
+      <div className="flex min-h-0 flex-1 flex-col p-3">
+        <div className="flex flex-col flex-wrap items-stretch justify-center gap-1 sm:flex-row sm:items-center">
+          {stages.map((stage, i) => (
+            <div
+              key={stage.key}
+              className="flex flex-col items-center gap-1 sm:flex-row"
+            >
+              <StageCard
+                stage={stage}
+                active={running && stage.key === RUNNING_STAGE}
+                hasResult={hasResult}
+              />
+              {i < stages.length - 1 && <Arrow />}
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 text-center text-[11px] text-ink-400">
+          {hasResult
+            ? `Mocha scanned ${result?.tokens.length ?? 0} tokens and ran ${
+                result?.stats.steps ?? 0
+              } bytecode steps.`
+            : 'Run a program to watch source flow through every stage.'}
+        </p>
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/components/charts/StackDepthChart.tsx
+++ b/web/src/components/charts/StackDepthChart.tsx
@@ -1,0 +1,334 @@
+/**
+ * Execution timeline chart: value-stack size (filled area, accent) and call
+ * depth (line, violet) plotted per trace step. Interactive — click/drag to
+ * scrub the current step. Downsamples the drawn paths for very long traces
+ * while keeping click mapping at full resolution.
+ */
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { Panel, EmptyState } from '../Panel'
+import { useStore } from '../../store'
+
+const DEPTH_COLOR = '#c490e4'
+const ACCENT = '#e0954a'
+const MAX_POINTS = 1000
+
+/** Pad applied inside the SVG viewBox so markers/labels do not clip. */
+const PAD = { top: 8, right: 8, bottom: 18, left: 8 }
+const VIEW_W = 1000
+const VIEW_H = 240
+const PLOT_W = VIEW_W - PAD.left - PAD.right
+const PLOT_H = VIEW_H - PAD.top - PAD.bottom
+
+interface Series {
+  /** Per-step value-stack size. */
+  stack: number[]
+  /** Per-step call depth. */
+  depth: number[]
+  maxStack: number
+  maxDepth: number
+}
+
+/** Map a step index (0..n-1) to an x coordinate within the plot area. */
+function stepToX(index: number, n: number): number {
+  if (n <= 1) return PAD.left + PLOT_W / 2
+  return PAD.left + (index / (n - 1)) * PLOT_W
+}
+
+/** Map a value 0..max to a y coordinate (inverted: 0 at bottom). */
+function valToY(value: number, max: number): number {
+  const frac = max <= 0 ? 0 : value / max
+  return PAD.top + PLOT_H - frac * PLOT_H
+}
+
+/** Indices to actually draw, downsampled to ~MAX_POINTS for long traces. */
+function sampleIndices(n: number): number[] {
+  if (n <= MAX_POINTS) {
+    const all: number[] = []
+    for (let i = 0; i < n; i++) all.push(i)
+    return all
+  }
+  const out: number[] = []
+  const stride = (n - 1) / (MAX_POINTS - 1)
+  for (let i = 0; i < MAX_POINTS; i++) out.push(Math.round(i * stride))
+  // Guarantee the final point is included.
+  if (out[out.length - 1] !== n - 1) out.push(n - 1)
+  return out
+}
+
+export function StackDepthChart() {
+  const result = useStore((s) => s.result)
+  const stepIndex = useStore((s) => s.stepIndex)
+  const setStep = useStore((s) => s.setStep)
+  const trace = result?.trace ?? []
+  const n = trace.length
+
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const draggingRef = useRef(false)
+  const [hover, setHover] = useState<number | null>(null)
+
+  const series = useMemo<Series>(() => {
+    const stack: number[] = []
+    const depth: number[] = []
+    let maxStack = 0
+    let maxDepth = 0
+    for (const step of trace) {
+      const s = step.stack.length
+      const d = step.depth
+      stack.push(s)
+      depth.push(d)
+      if (s > maxStack) maxStack = s
+      if (d > maxDepth) maxDepth = d
+    }
+    return { stack, depth, maxStack, maxDepth }
+  }, [trace])
+
+  const { stackArea, depthPath } = useMemo(() => {
+    if (n === 0) return { stackArea: '', depthPath: '' }
+    const idx = sampleIndices(n)
+    const yMaxStack = Math.max(1, series.maxStack)
+    const yMaxDepth = Math.max(1, series.maxDepth)
+
+    let area = ''
+    let line = ''
+    idx.forEach((i, k) => {
+      const x = stepToX(i, n)
+      const ys = valToY(series.stack[i], yMaxStack)
+      const yd = valToY(series.depth[i], yMaxDepth)
+      area += `${k === 0 ? 'M' : 'L'}${x.toFixed(2)},${ys.toFixed(2)} `
+      line += `${k === 0 ? 'M' : 'L'}${x.toFixed(2)},${yd.toFixed(2)} `
+    })
+    // Close the area path down to the baseline.
+    const lastX = stepToX(idx[idx.length - 1], n)
+    const firstX = stepToX(idx[0], n)
+    const baseY = PAD.top + PLOT_H
+    area += `L${lastX.toFixed(2)},${baseY.toFixed(2)} L${firstX.toFixed(2)},${baseY.toFixed(2)} Z`
+    return { stackArea: area.trim(), depthPath: line.trim() }
+  }, [n, series])
+
+  /** Convert a pointer event to a step index over the full (non-sampled) range. */
+  const eventToStep = useCallback(
+    (clientX: number): number | null => {
+      const svg = svgRef.current
+      if (!svg || n === 0) return null
+      const rect = svg.getBoundingClientRect()
+      if (rect.width === 0) return null
+      // Translate client px -> viewBox units -> plot fraction.
+      const vbX = ((clientX - rect.left) / rect.width) * VIEW_W
+      const frac = (vbX - PAD.left) / PLOT_W
+      const clamped = Math.min(1, Math.max(0, frac))
+      return Math.round(clamped * (n - 1))
+    },
+    [n],
+  )
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const i = eventToStep(e.clientX)
+      if (i === null) return
+      draggingRef.current = true
+      e.currentTarget.setPointerCapture(e.pointerId)
+      setHover(i)
+      setStep(i)
+    },
+    [eventToStep, setStep],
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const i = eventToStep(e.clientX)
+      if (i === null) return
+      setHover(i)
+      if (draggingRef.current) setStep(i)
+    },
+    [eventToStep, setStep],
+  )
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      draggingRef.current = false
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      }
+    },
+    [],
+  )
+
+  // Keep the hover readout in sync with the current step when not interacting.
+  useLayoutEffect(() => {
+    if (!draggingRef.current) setHover(null)
+  }, [stepIndex])
+
+  if (n === 0) {
+    return (
+      <Panel
+        title="Execution timeline"
+        subtitle="stack size & call depth per step"
+      >
+        <EmptyState>Run a script to see how the stack grows over time.</EmptyState>
+      </Panel>
+    )
+  }
+
+  const readoutIndex = hover ?? (stepIndex >= 0 && stepIndex < n ? stepIndex : null)
+  const readout = readoutIndex !== null ? trace[readoutIndex] : null
+
+  const markerIndex = stepIndex >= 0 && stepIndex < n ? stepIndex : null
+  const markerX = markerIndex !== null ? stepToX(markerIndex, n) : null
+  const hoverX = hover !== null ? stepToX(hover, n) : null
+
+  // Horizontal gridlines at quarter intervals.
+  const gridY = [0.25, 0.5, 0.75].map((f) => PAD.top + PLOT_H - f * PLOT_H)
+
+  return (
+    <Panel
+      title="Execution timeline"
+      subtitle="stack size & call depth per step"
+      actions={
+        <div className="flex items-center gap-3 text-[10px] text-ink-300">
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block h-2 w-2 rounded-sm"
+              style={{ backgroundColor: ACCENT }}
+            />
+            stack
+          </span>
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block h-2 w-3 rounded-sm"
+              style={{ backgroundColor: DEPTH_COLOR }}
+            />
+            depth
+          </span>
+        </div>
+      }
+      bodyClassName="flex flex-col"
+    >
+      <div className="flex min-h-0 flex-1 flex-col p-3">
+        <div className="relative min-h-0 flex-1">
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+            preserveAspectRatio="none"
+            className="h-full w-full cursor-crosshair touch-none select-none"
+            role="slider"
+            aria-label="Execution step"
+            aria-valuemin={0}
+            aria-valuemax={n - 1}
+            aria-valuenow={markerIndex ?? 0}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerLeave={handlePointerUp}
+          >
+            {/* baseline + gridlines */}
+            {gridY.map((y, i) => (
+              <line
+                key={i}
+                x1={PAD.left}
+                x2={PAD.left + PLOT_W}
+                y1={y}
+                y2={y}
+                stroke="#ffffff"
+                strokeOpacity={0.05}
+                strokeWidth={1}
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+            <line
+              x1={PAD.left}
+              x2={PAD.left + PLOT_W}
+              y1={PAD.top + PLOT_H}
+              y2={PAD.top + PLOT_H}
+              stroke="#ffffff"
+              strokeOpacity={0.12}
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+
+            {/* stack area */}
+            <path d={stackArea} fill={ACCENT} fillOpacity={0.16} />
+            <path
+              d={stackArea}
+              fill="none"
+              stroke={ACCENT}
+              strokeOpacity={0.55}
+              strokeWidth={1.5}
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+            />
+
+            {/* depth line */}
+            <path
+              d={depthPath}
+              fill="none"
+              stroke={DEPTH_COLOR}
+              strokeWidth={1.5}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+
+            {/* hover marker (faint) */}
+            {hoverX !== null && hoverX !== markerX && (
+              <line
+                x1={hoverX}
+                x2={hoverX}
+                y1={PAD.top}
+                y2={PAD.top + PLOT_H}
+                stroke="#ffffff"
+                strokeOpacity={0.18}
+                strokeWidth={1}
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+
+            {/* current-step marker */}
+            {markerX !== null && (
+              <line
+                x1={markerX}
+                x2={markerX}
+                y1={PAD.top}
+                y2={PAD.top + PLOT_H}
+                stroke={ACCENT}
+                strokeWidth={1.5}
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </svg>
+
+          {/* axis max labels (overlaid, non-distorting) */}
+          <div className="pointer-events-none absolute left-1 top-1 font-mono text-[10px] leading-none text-ink-400">
+            stack max {series.maxStack}
+          </div>
+          <div className="pointer-events-none absolute right-1 top-1 font-mono text-[10px] leading-none text-ink-400">
+            depth max {series.maxDepth}
+          </div>
+          <div className="pointer-events-none absolute bottom-1 left-1 font-mono text-[10px] leading-none text-ink-400">
+            step 0
+          </div>
+          <div className="pointer-events-none absolute bottom-1 right-1 font-mono text-[10px] leading-none text-ink-400">
+            step {n - 1}
+          </div>
+        </div>
+
+        {/* readout */}
+        <div className="mt-2 flex shrink-0 items-center gap-4 border-t border-ink-600 pt-2 font-mono text-[11px]">
+          {readout ? (
+            <>
+              <span className="text-ink-200">
+                step <span className="text-ink-100">{readout.step}</span>
+              </span>
+              <span style={{ color: ACCENT }}>
+                stack {readout.stack.length}
+              </span>
+              <span style={{ color: DEPTH_COLOR }}>depth {readout.depth}</span>
+              <span className="truncate text-ink-400">{readout.op}</span>
+            </>
+          ) : (
+            <span className="text-ink-400">hover or drag to inspect a step</span>
+          )}
+        </div>
+      </div>
+    </Panel>
+  )
+}

--- a/web/src/engine/examples.ts
+++ b/web/src/engine/examples.ts
@@ -1,0 +1,74 @@
+/** Curated sample programs that exercise the 1995 engine's features. */
+export interface Example {
+  id: string
+  title: string
+  blurb: string
+  code: string
+}
+
+export const EXAMPLES: Example[] = [
+  {
+    id: 'hello',
+    title: 'Hello, Mocha',
+    blurb: 'The classic — a function call and print.',
+    code: `function hello(name) {
+  print('hello', name)
+}
+hello('mocha')`,
+  },
+  {
+    id: 'factorial',
+    title: 'Recursion',
+    blurb: 'Recursive factorial — watch the call stack grow.',
+    code: `function fact(n) {
+  if (n < 2) return 1
+  return n * fact(n - 1)
+}
+print('5! =', fact(5))`,
+  },
+  {
+    id: 'loop',
+    title: 'Loops & bytecode',
+    blurb: 'A for-loop compiles to goto/ifne — see the jumps.',
+    code: `var sum = 0
+for (var i = 1; i <= 10; i = i + 1) {
+  sum = sum + i
+}
+print('sum 1..10 =', sum)`,
+  },
+  {
+    id: 'fib',
+    title: 'Fibonacci',
+    blurb: 'Tree recursion — a deep, branchy execution trace.',
+    code: `function fib(n) {
+  if (n < 2) return n
+  return fib(n - 1) + fib(n - 2)
+}
+print('fib(7) =', fib(7))`,
+  },
+  {
+    id: 'operators',
+    title: 'Operators',
+    blurb: 'Arithmetic, comparison and bitwise opcodes.',
+    code: `var a = 6, b = 4
+print('add', a + b)
+print('mul', a * b)
+print('cmp', a > b)
+print('bit', a & b, a | b, a ^ b)
+print('shift', a << 1, a >> 1)`,
+  },
+  {
+    id: 'conditional',
+    title: 'Conditionals',
+    blurb: 'if/else and the ?: operator branch the bytecode.',
+    code: `function classify(n) {
+  if (n < 0) return 'negative'
+  return n == 0 ? 'zero' : 'positive'
+}
+print(classify(-3))
+print(classify(0))
+print(classify(42))`,
+  },
+]
+
+export const DEFAULT_CODE = EXAMPLES[1].code

--- a/web/src/engine/runner.ts
+++ b/web/src/engine/runner.ts
@@ -1,0 +1,55 @@
+/**
+ * Loads the Mocha 1995 engine (compiled to WebAssembly) and runs source code,
+ * returning the structured RunResult. The .mjs/.wasm pair lives in
+ * /public/engine and is produced by ../../build_wasm.sh.
+ */
+import type { RunResult } from './types'
+
+interface MochaModule {
+  cwrap: (
+    name: string,
+    ret: string | null,
+    args: string[],
+  ) => (...a: unknown[]) => number
+  UTF8ToString: (ptr: number) => string
+  _free: (ptr: number) => void
+}
+
+type ModuleFactory = (opts?: Record<string, unknown>) => Promise<MochaModule>
+
+let modulePromise: Promise<{
+  mod: MochaModule
+  run: (src: string) => number
+}> | null = null
+
+// Resolve the engine URL relative to the deployed base path.
+const engineUrl = new URL('engine/mocha.mjs', document.baseURI).href
+
+async function load() {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const factory: ModuleFactory = (
+        await import(/* @vite-ignore */ engineUrl)
+      ).default
+      const mod = await factory()
+      const run = mod.cwrap('mocha_run_json', 'number', ['string'])
+      return { mod, run: run as (src: string) => number }
+    })()
+  }
+  return modulePromise
+}
+
+/** Kick off engine loading early (e.g. on app mount). */
+export function preloadEngine(): void {
+  void load()
+}
+
+/** Compile and run `source` with the original engine. */
+export async function runMocha(source: string): Promise<RunResult> {
+  const { mod, run } = await load()
+  const ptr = run(source)
+  if (!ptr) throw new Error('engine returned null')
+  const json = mod.UTF8ToString(ptr)
+  mod._free(ptr)
+  return JSON.parse(json) as RunResult
+}

--- a/web/src/engine/types.ts
+++ b/web/src/engine/types.ts
@@ -1,0 +1,114 @@
+/**
+ * TypeScript mirror of the JSON document emitted by `mocha_run_json` in
+ * src/mo_web.c. Keep these in sync with the C serializer.
+ */
+
+/** A single scanned token from the original Mocha scanner (mo_scan.c). */
+export interface Token {
+  index: number
+  /** Token class, e.g. "FUNCTION", "NAME", "NUMBER", "PLUS". */
+  type: string
+  /** 1-based source line. */
+  line: number
+  /** 0-based column within the line. */
+  col: number
+  /** Source lexeme (exact for NAME/NUMBER/STRING, representative otherwise). */
+  text: string
+}
+
+/** Operand of a bytecode instruction; shape depends on `format`. */
+export type Operand =
+  | null
+  | string
+  | number
+  | { target: number; delta: number } // MOF_JUMP
+
+export type OpFormat = 'byte' | 'jump' | 'incop' | 'argc' | 'const'
+
+/** One disassembled bytecode instruction (mo_bcode.c / mocha.def). */
+export interface Instruction {
+  /** Byte offset within its script's code. */
+  offset: number
+  /** Mnemonic, e.g. "add", "call", "ifeq". */
+  op: string
+  /** Instruction length in bytes. */
+  length: number
+  /** Stack slots consumed (-1 = variadic). */
+  nuses: number
+  /** Stack slots produced. */
+  ndefs: number
+  /** Source line this instruction came from. */
+  line: number
+  format: OpFormat
+  operand: Operand
+}
+
+/** A compiled script: the top-level program or a function body. */
+export interface Script {
+  id: number
+  /** "<main>" for the program, else the function name. */
+  name: string
+  bytecode: Instruction[]
+}
+
+/** A value-stack entry, captured without invoking user code. */
+export interface Datum {
+  type:
+    | 'undefined'
+    | 'number'
+    | 'boolean'
+    | 'string'
+    | 'object'
+    | 'function'
+    | 'atom'
+    | 'symbol'
+    | 'internal'
+    | 'unknown'
+  value: string
+}
+
+/** Active call frame at a trace step. */
+export interface Frame {
+  fn: string
+  args: Datum[]
+  vars: Datum[]
+}
+
+/** One interpreter step, captured before the instruction is dispatched. */
+export interface TraceStep {
+  step: number
+  /** Index into `RunResult.scripts` of the executing script. */
+  script: number
+  /** Byte offset (program counter) within that script. */
+  pc: number
+  /** Source line. */
+  line: number
+  /** Mnemonic about to execute. */
+  op: string
+  /** Call depth (0 = top level). */
+  depth: number
+  /** Value stack (most recent STACK_WINDOW entries). */
+  stack: Datum[]
+  frame: Frame | null
+}
+
+export interface MochaError {
+  message: string
+  line: number
+  col: number
+  linebuf: string
+}
+
+/** Full result of compiling and running a program. */
+export interface RunResult {
+  ok: boolean
+  output: string
+  error: MochaError | null
+  result: Datum | null
+  tokens: Token[]
+  scripts: Script[]
+  trace: TraceStep[]
+  /** True if execution hit the step cap (runaway loop guard). */
+  truncated: boolean
+  stats: { steps: number; scripts: number }
+}

--- a/web/src/hooks/usePlayLoop.ts
+++ b/web/src/hooks/usePlayLoop.ts
@@ -1,0 +1,30 @@
+/**
+ * Drives the debugger's "play" transport: while `playing` is true, advances
+ * the trace one step at a time at `speed` steps/second, pausing at the end.
+ */
+import { useEffect } from 'react'
+import { useStore } from '../store'
+
+export function usePlayLoop(): void {
+  const playing = useStore((s) => s.playing)
+  const speed = useStore((s) => s.speed)
+
+  useEffect(() => {
+    if (!playing) return
+    const interval = Math.max(16, 1000 / Math.max(1, speed))
+    const id = window.setInterval(() => {
+      const s = useStore.getState()
+      const len = s.result?.trace.length ?? 0
+      if (len === 0) {
+        s.pause()
+        return
+      }
+      if (s.stepIndex >= len - 1) {
+        s.pause()
+        return
+      }
+      s.stepForward()
+    }, interval)
+    return () => window.clearInterval(id)
+  }, [playing, speed])
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,87 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-mocha-50: #faf6f0;
+  --color-mocha-100: #f0e6d8;
+  --color-mocha-200: #e0cab0;
+  --color-mocha-300: #c9a47b;
+  --color-mocha-400: #b3814f;
+  --color-mocha-500: #8a5a2b;
+  --color-mocha-600: #6f4520;
+  --color-mocha-700: #523219;
+  --color-mocha-800: #3a2412;
+  --color-mocha-900: #24160b;
+
+  --color-ink-900: #0e1116;
+  --color-ink-800: #151a21;
+  --color-ink-700: #1c232c;
+  --color-ink-600: #283038;
+  --color-ink-500: #3a444f;
+  --color-ink-400: #5b6672;
+  --color-ink-300: #8a97a4;
+  --color-ink-200: #b9c2cc;
+  --color-ink-100: #e3e8ed;
+
+  --color-accent: #e0954a;
+  --color-accent-bright: #f4b063;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--color-ink-900);
+  color: var(--color-ink-100);
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.font-mono,
+.cm-editor {
+  font-family:
+    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* Thin custom scrollbars for the panels. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-ink-500) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--color-ink-500);
+  border-radius: 4px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@keyframes pop-in {
+  from {
+    transform: translateY(6px) scale(0.96);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+.animate-pop-in {
+  animation: pop-in 0.18s ease-out;
+}
+
+/* Highlight applied to the current source line during debugging. */
+.cm-current-line-debug {
+  background: rgba(224, 149, 74, 0.16) !important;
+}
+.cm-error-line {
+  background: rgba(239, 68, 68, 0.18) !important;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { App } from './App'
+import { preloadEngine } from './engine/runner'
+
+// Start fetching/compiling the WASM engine immediately.
+preloadEngine()
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,0 +1,129 @@
+/**
+ * Central app + debugger state. Every panel reads from here so the editor,
+ * token view, bytecode view, stack, call stack and charts all stay in sync
+ * with the single "current step" of the execution trace.
+ */
+import { create } from 'zustand'
+import type { RunResult, TraceStep } from './engine/types'
+import { runMocha } from './engine/runner'
+import { DEFAULT_CODE } from './engine/examples'
+
+export type RunStatus = 'idle' | 'running' | 'done' | 'error'
+
+interface AppState {
+  // --- source + run ---
+  code: string
+  status: RunStatus
+  result: RunResult | null
+  loadError: string | null
+  setCode: (code: string) => void
+  run: () => Promise<void>
+
+  // --- debugger transport ---
+  /** Index into result.trace, or -1 when no step is selected. */
+  stepIndex: number
+  playing: boolean
+  /** Steps per second when playing. */
+  speed: number
+  setStep: (i: number) => void
+  stepForward: () => void
+  stepBack: () => void
+  stepOver: () => void // advance to next step at same-or-shallower depth
+  play: () => void
+  pause: () => void
+  togglePlay: () => void
+  reset: () => void
+  setSpeed: (s: number) => void
+}
+
+function clampStep(i: number, len: number): number {
+  if (len === 0) return -1
+  return Math.max(0, Math.min(i, len - 1))
+}
+
+export const useStore = create<AppState>((set, get) => ({
+  code: DEFAULT_CODE,
+  status: 'idle',
+  result: null,
+  loadError: null,
+
+  setCode: (code) => set({ code }),
+
+  run: async () => {
+    set({ status: 'running', loadError: null })
+    try {
+      const result = await runMocha(get().code)
+      set({
+        result,
+        status: result.ok ? 'done' : 'error',
+        stepIndex: result.trace.length ? 0 : -1,
+        playing: false,
+      })
+    } catch (e) {
+      set({
+        status: 'error',
+        loadError: e instanceof Error ? e.message : String(e),
+        result: null,
+        stepIndex: -1,
+        playing: false,
+      })
+    }
+  },
+
+  stepIndex: -1,
+  playing: false,
+  speed: 6,
+
+  setStep: (i) => {
+    const len = get().result?.trace.length ?? 0
+    set({ stepIndex: clampStep(i, len), playing: false })
+  },
+
+  stepForward: () => {
+    const { stepIndex, result } = get()
+    const len = result?.trace.length ?? 0
+    if (len === 0) return
+    set({ stepIndex: clampStep(stepIndex + 1, len) })
+  },
+
+  stepBack: () => {
+    const { stepIndex, result } = get()
+    const len = result?.trace.length ?? 0
+    if (len === 0) return
+    set({ stepIndex: clampStep(stepIndex - 1, len), playing: false })
+  },
+
+  stepOver: () => {
+    const { stepIndex, result } = get()
+    const trace = result?.trace
+    if (!trace || trace.length === 0) return
+    const cur: TraceStep | undefined = trace[stepIndex]
+    if (!cur) {
+      set({ stepIndex: 0 })
+      return
+    }
+    let i = stepIndex + 1
+    while (i < trace.length && trace[i].depth > cur.depth) i++
+    set({ stepIndex: clampStep(i, trace.length), playing: false })
+  },
+
+  play: () => {
+    const { result, stepIndex } = get()
+    const len = result?.trace.length ?? 0
+    if (len === 0) return
+    if (stepIndex >= len - 1) set({ stepIndex: 0 })
+    set({ playing: true })
+  },
+  pause: () => set({ playing: false }),
+  togglePlay: () => (get().playing ? get().pause() : get().play()),
+  reset: () =>
+    set({ stepIndex: get().result?.trace.length ? 0 : -1, playing: false }),
+  setSpeed: (speed) => set({ speed }),
+}))
+
+/** Convenience selector: the currently selected trace step (or null). */
+export function useCurrentStep(): TraceStep | null {
+  return useStore((s) =>
+    s.result && s.stepIndex >= 0 ? s.result.trace[s.stepIndex] ?? null : null,
+  )
+}

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared visual language: maps token classes and bytecode opcodes to colour
+ * categories so the token view, bytecode view, trace and charts agree.
+ * Colours are plain hex (used in SVG and inline styles); Tailwind classes are
+ * provided where a utility string is more convenient.
+ */
+
+export interface CategoryStyle {
+  /** Hex colour for SVG / inline styles. */
+  hex: string
+  /** Tailwind text + bg/border classes for chips. */
+  chip: string
+  label: string
+}
+
+/** Broad opcode categories used for colour-coding instructions and the stack. */
+export type OpCategory =
+  | 'load' // push constants/names
+  | 'arith' // +,-,*,/ ...
+  | 'logic' // comparisons, bitwise, not
+  | 'control' // goto/ifeq/ifne/return
+  | 'call' // call/new
+  | 'store' // assign/inc/dec
+  | 'member' // member/index access
+  | 'stack' // push/pop/dup
+  | 'other'
+
+export const OP_CATEGORY: Record<string, OpCategory> = {
+  push: 'stack', pop: 'stack', dup: 'stack', nop: 'other',
+  name: 'load', number: 'load', string: 'load', zero: 'load', one: 'load',
+  null: 'load', this: 'load', true: 'load', false: 'load',
+  add: 'arith', sub: 'arith', mul: 'arith', div: 'arith', mod: 'arith',
+  neg: 'arith',
+  bitor: 'logic', bitxor: 'logic', bitand: 'logic', bitnot: 'logic',
+  eq: 'logic', ne: 'logic', lt: 'logic', le: 'logic', gt: 'logic', ge: 'logic',
+  lsh: 'logic', rsh: 'logic', ursh: 'logic', not: 'logic', in: 'logic',
+  typeof: 'logic', void: 'logic',
+  goto: 'control', ifeq: 'control', ifne: 'control', return: 'control',
+  enter: 'control', leave: 'control', trap: 'control',
+  call: 'call', new: 'call',
+  assign: 'store', inc: 'store', dec: 'store', delete: 'store',
+  member: 'member', lmember: 'member', index: 'member', lindex: 'member',
+}
+
+export const CATEGORY_STYLE: Record<OpCategory, CategoryStyle> = {
+  load: { hex: '#5ec5d6', chip: 'text-cyan-200 bg-cyan-500/15 border-cyan-500/30', label: 'Load' },
+  arith: { hex: '#f4b063', chip: 'text-amber-200 bg-amber-500/15 border-amber-500/30', label: 'Arithmetic' },
+  logic: { hex: '#c490e4', chip: 'text-purple-200 bg-purple-500/15 border-purple-500/30', label: 'Logic' },
+  control: { hex: '#ef6f6f', chip: 'text-red-200 bg-red-500/15 border-red-500/30', label: 'Control flow' },
+  call: { hex: '#7ee08a', chip: 'text-green-200 bg-green-500/15 border-green-500/30', label: 'Call' },
+  store: { hex: '#e0954a', chip: 'text-orange-200 bg-orange-500/15 border-orange-500/30', label: 'Store' },
+  member: { hex: '#8ab4f8', chip: 'text-blue-200 bg-blue-500/15 border-blue-500/30', label: 'Member' },
+  stack: { hex: '#9aa7b3', chip: 'text-slate-200 bg-slate-500/15 border-slate-500/30', label: 'Stack' },
+  other: { hex: '#6b7682', chip: 'text-slate-300 bg-slate-600/15 border-slate-600/30', label: 'Other' },
+}
+
+export function opCategory(op: string): OpCategory {
+  return OP_CATEGORY[op] ?? 'other'
+}
+
+export function opStyle(op: string): CategoryStyle {
+  return CATEGORY_STYLE[opCategory(op)]
+}
+
+/** Token classes grouped for colouring the scanner output. */
+export type TokenGroup =
+  | 'keyword'
+  | 'identifier'
+  | 'number'
+  | 'string'
+  | 'operator'
+  | 'punct'
+  | 'primary'
+
+const KEYWORDS = new Set([
+  'FUNCTION', 'IF', 'ELSE', 'SWITCH', 'CASE', 'DEFAULT', 'WHILE', 'DO', 'FOR',
+  'BREAK', 'CONTINUE', 'IN', 'VAR', 'WITH', 'RETURN', 'NEW', 'RESERVED',
+])
+const OPERATORS = new Set([
+  'ASSIGN', 'HOOK', 'COLON', 'OR', 'AND', 'BITOR', 'BITXOR', 'BITAND', 'EQOP',
+  'RELOP', 'SHOP', 'PLUS', 'MINUS', 'MULOP', 'UNARYOP', 'INCOP', 'DOT',
+])
+const PUNCT = new Set([
+  'SEMI', 'LB', 'RB', 'LC', 'RC', 'LP', 'RP', 'COMMA', 'EOL', 'EOF',
+])
+
+export function tokenGroup(type: string): TokenGroup {
+  if (KEYWORDS.has(type)) return 'keyword'
+  if (OPERATORS.has(type)) return 'operator'
+  if (PUNCT.has(type)) return 'punct'
+  if (type === 'NAME') return 'identifier'
+  if (type === 'NUMBER') return 'number'
+  if (type === 'STRING') return 'string'
+  if (type === 'PRIMARY') return 'primary'
+  return 'punct'
+}
+
+export const TOKEN_STYLE: Record<TokenGroup, CategoryStyle> = {
+  keyword: { hex: '#c490e4', chip: 'text-purple-200 bg-purple-500/15 border-purple-500/30', label: 'Keyword' },
+  identifier: { hex: '#8ab4f8', chip: 'text-blue-200 bg-blue-500/15 border-blue-500/30', label: 'Identifier' },
+  number: { hex: '#f4b063', chip: 'text-amber-200 bg-amber-500/15 border-amber-500/30', label: 'Number' },
+  string: { hex: '#7ee08a', chip: 'text-green-200 bg-green-500/15 border-green-500/30', label: 'String' },
+  operator: { hex: '#5ec5d6', chip: 'text-cyan-200 bg-cyan-500/15 border-cyan-500/30', label: 'Operator' },
+  punct: { hex: '#9aa7b3', chip: 'text-slate-300 bg-slate-500/15 border-slate-500/30', label: 'Punctuation' },
+  primary: { hex: '#ef9f6f', chip: 'text-orange-200 bg-orange-500/15 border-orange-500/30', label: 'Primary' },
+}
+
+export function tokenStyle(type: string): CategoryStyle {
+  return TOKEN_STYLE[tokenGroup(type)]
+}
+
+/** Colour for a datum on the value stack, by runtime type. */
+export function datumColor(type: string): string {
+  switch (type) {
+    case 'number': return '#f4b063'
+    case 'string': return '#7ee08a'
+    case 'boolean': return '#c490e4'
+    case 'object': return '#8ab4f8'
+    case 'function': return '#5ec5d6'
+    case 'undefined': return '#6b7682'
+    default: return '#9aa7b3'
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "allowJs": true
+  },
+  "include": ["src"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  base: './',
+  server: { port: 5173 },
+})


### PR DESCRIPTION
## Summary

Rewrites the playground as a modern **Vite + React + TypeScript + Tailwind** app that runs Brendan Eich's original 1995 Mocha engine (compiled to WebAssembly) and **visualizes how it works** — the scanner's token stream, the compiled bytecode, and an interactive step-debugger over the *real* execution trace.

Crucially, this debugs the **actual C engine**, not a reimplementation. The engine is exposed through a tiny instrumentation layer and otherwise left untouched.

## Engine instrumentation

- **One-line hook** in the interpreter loop (`src/mocha.c`): a `mocha_TraceHook` call fired once per bytecode instruction (`include/mo_introspect.h`).
- **`src/mo_web.c`** — a self-contained Emscripten embedder exposing `mocha_run_json(source)`, returning one JSON document:
  - `tokens` — scanner output (`mo_scan.c`)
  - `scripts` — per-function bytecode disassembly (`mocha.def`)
  - `trace` — per-instruction execution trace (program counter, value stack, call frame + argument values, depth)
  - `output`, `result`, structured `error`
  - runaway-loop protection via the branch callback
- **`build_wasm.sh`** — reproducible build → `web/public/engine/mocha.{mjs,wasm}` (needs Emscripten on PATH).

## Frontend (`web/`)

- Source editor (CodeMirror) with live current-line / error highlighting
- Tokens, bytecode (per-script tabs, operands, jump targets, active-instruction highlight), console with rich errors
- Interactive debugger: play / pause / step / step-over / scrub — editor, bytecode, value stack, call stack and charts all synced to the current step
- Value stack & call stack (real frames with argument values)
- Charts: engine pipeline, execution timeline (stack size & call depth), opcode profile

## Verification

Built and verified end-to-end in headless Chrome: no page/console errors, no 404s; `fact(5)=120` and `fib(7)=13` compute correctly; scrubbing the timeline drives step/line/op/depth across all panels in sync. `tsc` and `vite build` both pass clean.

## Run it

```sh
source /path/to/emsdk/emsdk_env.sh   # emcc on PATH
bash build_wasm.sh                   # build engine -> wasm
cd web && npm install && npm run dev # http://localhost:5173
```

Built engine artifacts and `node_modules`/`dist` are git-ignored; regenerate with `build_wasm.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)