### PR TITLE
ci: deploy new web playground to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy Playground to GitHub Pages
+
+# Builds the WASM engine + the Vite playground in web/ and publishes web/dist
+# to GitHub Pages. Requires the repo's Pages source to be set to "GitHub Actions"
+# (Settings → Pages → Build and deployment → Source).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow this workflow to publish to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deploy at a time; don't cancel an in-progress run mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 3.1.64
+          actions-cache-folder: emsdk-cache
+
+      - name: Build engine to WASM
+        run: bash build_wasm.sh
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build playground
+        working-directory: web
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+mocha1995.js.org


### PR DESCRIPTION
## What

Switches the live site (`mocha1995.js.org`) from the legacy `gh-pages` homepage to the new Vite + React + TS + Tailwind playground in `web/`.

Adds a GitHub Actions workflow that, on every push to `main`:

1. Sets up Emscripten and runs `build_wasm.sh` → produces `web/public/engine/mocha.{mjs,wasm}` (these stay gitignored; built fresh in CI).
2. `npm ci && npm run build` in `web/` → static output in `web/dist`.
3. Publishes `web/dist` to GitHub Pages.

`web/public/CNAME` ships the custom domain so it survives every build.

## Why it works on Pages

- Fully static Vite output; `base: './'` + runtime engine load via `new URL('engine/mocha.mjs', document.baseURI)` → all relative, works under the custom domain root.
- Engine is built without pthreads/SharedArrayBuffer, so **no COOP/COEP headers needed** (Pages can't set custom headers anyway).

## Manual step required before this takes effect

After merge, switch **Settings → Pages → Build and deployment → Source** from "Deploy from a branch" to **"GitHub Actions"**. (Can also be done via API — see the PR thread.) The old `gh-pages` branch can be deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)